### PR TITLE
Gorilla mux and stdhttp adapters and examples

### DIFF
--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -3,9 +3,10 @@ package gorilla_adapter
 import (
 	"net/http"
 
-	"github.com/AdrianTworek/go-auth/core"
 	"github.com/gorilla/mux"
 	"github.com/markbates/goth/gothic"
+
+	"github.com/AdrianTworek/go-auth/core"
 )
 
 type GorillaParamExtractor struct {

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -1,0 +1,54 @@
+package gorilla_adapter
+
+import (
+	"net/http"
+
+	"github.com/AdrianTworek/go-auth/core"
+	"github.com/gorilla/mux"
+	"github.com/markbates/goth/gothic"
+)
+
+type GorillaParamExtractor struct {
+	Vars map[string]string
+}
+
+func (g *GorillaParamExtractor) GetParam(key string) string {
+	return g.Vars[key]
+}
+
+func InitAuth(ac *core.AuthClient, r *mux.Router) {
+	if ac.CanLoginWithOAuth() {
+		ac.SetupGoth()
+	}
+
+	publicRouter := r.PathPrefix("/auth").Subrouter()
+	publicRouter.HandleFunc("/register", ac.RegisterHandler()).Methods("POST")
+	publicRouter.HandleFunc("/login", ac.LoginHandler()).Methods("POST")
+	publicRouter.HandleFunc("/verify/{token}", func(w http.ResponseWriter, r *http.Request) {
+		ac.VerifyEmailHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
+	}).Methods("GET")
+
+	if ac.CanLoginWithOAuth() {
+		publicRouter.HandleFunc("/oauth", func(w http.ResponseWriter, r *http.Request) {
+			gothic.BeginAuthHandler(w, r)
+		}).Methods("GET")
+		publicRouter.HandleFunc("/oauth/callback", ac.OAuthCallbackHandler()).Methods("GET")
+	}
+
+	publicRouter.HandleFunc("/magic-link", ac.SendMagicLinkHandler()).Methods("POST")
+	publicRouter.HandleFunc("/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		ac.CompleteMagicLinkSignInHandler(&GorillaParamExtractor{Vars: vars}).ServeHTTP(w, r)
+	}).Methods("GET")
+
+	publicRouter.HandleFunc("/reset-password", ac.SendPasswordResetLinkHandler()).Methods("POST")
+	publicRouter.HandleFunc("/reset-password/{token}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		ac.CompletePasswordResetHandler(&GorillaParamExtractor{Vars: vars}).ServeHTTP(w, r)
+	}).Methods("PUT")
+
+	protectedRouter := r.PathPrefix("/auth").Subrouter()
+	protectedRouter.Use(ac.AuthMiddleware())
+	protectedRouter.HandleFunc("/me", ac.GetMeHandler()).Methods("GET")
+	protectedRouter.HandleFunc("/logout", ac.LogoutHandler()).Methods("POST")
+}

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -1,0 +1,48 @@
+package stdhttp_adapter
+
+import (
+	"net/http"
+
+	"github.com/markbates/goth/gothic"
+
+	"github.com/AdrianTworek/go-auth/core"
+)
+
+type StdHTTPParamExtractor struct {
+	Req *http.Request
+}
+
+func (s *StdHTTPParamExtractor) GetParam(key string) string {
+	return s.Req.PathValue(key)
+}
+
+func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
+	if ac.CanLoginWithOAuth() {
+		ac.SetupGoth()
+	}
+
+	mux.Handle("POST /auth/register", ac.RegisterHandler())
+	mux.Handle("POST /auth/login", ac.LoginHandler())
+	mux.HandleFunc("GET /auth/verify/{token}", func(w http.ResponseWriter, r *http.Request) {
+		ac.VerifyEmailHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+	})
+
+	if ac.CanLoginWithOAuth() {
+		mux.HandleFunc("GET /auth/oauth", gothic.BeginAuthHandler)
+		mux.Handle("GET /auth/oauth/callback", ac.OAuthCallbackHandler())
+	}
+
+	mux.Handle("POST /auth/magic-link", ac.SendMagicLinkHandler())
+	mux.HandleFunc("GET /auth/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
+		ac.CompleteMagicLinkSignInHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+	})
+
+	mux.Handle("POST /auth/reset-password", ac.SendPasswordResetLinkHandler())
+	mux.HandleFunc("PUT /auth/reset-password/{token}", func(w http.ResponseWriter, r *http.Request) {
+		ac.CompletePasswordResetHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+	})
+
+	authMiddleware := ac.AuthMiddleware()
+	mux.Handle("GET /auth/me", authMiddleware(ac.GetMeHandler()))
+	mux.Handle("POST /auth/logout", authMiddleware(ac.LogoutHandler()))
+}

--- a/examples/gorilla/gorilla.go
+++ b/examples/gorilla/gorilla.go
@@ -1,22 +1,46 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 
-	gorilla_adapter "github.com/AdrianTworek/go-auth/adapters/gorilla"
-	"github.com/AdrianTworek/go-auth/core"
-	"github.com/AdrianTworek/go-auth/examples"
 	"github.com/gorilla/mux"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/github"
 	"github.com/markbates/goth/providers/google"
 	"github.com/spf13/viper"
+
+	gorilla_adapter "github.com/AdrianTworek/go-auth/adapters/gorilla"
+	"github.com/AdrianTworek/go-auth/core"
+	"github.com/AdrianTworek/go-auth/examples"
 )
 
 func init() {
 	examples.SetupEnv()
+}
+
+func beforeLogin(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("this is from the before login hook", "event", event)
+	return nil
+}
+
+func afterLogin(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("this is from the after login hook", "event", event)
+	return &core.HookRedirect{
+		URL:    "http://localhost:8080/front/success",
+		Status: http.StatusFound,
+	}
+}
+
+func emailVerificationFailed(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("email verification failed")
+	return &core.HookRedirect{
+		URL:    "http://localhost:8080/front/failed",
+		Status: http.StatusFound,
+	}
 }
 
 func main() {
@@ -27,9 +51,12 @@ func main() {
 			Dsn: viper.GetString("DSN"),
 		},
 		Session: &core.SessionConfig{
-			MagicLinkSuccesfulRedirectURL: "http://localhost:8080/front/success",
-			MagicLinkFailedRedirectURL:    "http://localhost:8080/front/failed",
-			LoginAfterRegister:            true,
+			MagicLinkSuccessfulRedirectURL: "http://localhost:8080/front/success",
+			MagicLinkFailedRedirectURL:     "http://localhost:8080/front/failed",
+			LoginAfterRegister:             true,
+			// This example runs over plain HTTP, so disable Secure to let the
+			// browser send the session cookie. Remove this in production (HTTPS).
+			CookieSecure: core.Ptr(false),
 		},
 		OAuth: &core.OAuthConfig{
 			Providers: []goth.Provider{
@@ -54,8 +81,20 @@ func main() {
 				),
 			},
 		},
+		SessionSecret: viper.GetString("SESSION_SECRET"),
+		BaseURL:       "http://localhost:8080",
+		Hooks: &core.HookMap{
+			core.EventBeforeLogin: core.HookList{
+				beforeLogin,
+			},
+			core.EventAfterLogin: core.HookList{
+				afterLogin,
+			},
+			core.EventEmailVerificationFailed: core.HookList{
+				emailVerificationFailed,
+			},
+		},
 	})
-
 	if err != nil {
 		log.Fatalf("Error creating auth client: %v", err)
 	}
@@ -73,7 +112,7 @@ func main() {
 			</body>
 		</html>
 		`
-		w.Write([]byte(html))
+		_, _ = w.Write([]byte(html))
 	})
 
 	r.HandleFunc("/front/failed", func(w http.ResponseWriter, r *http.Request) {
@@ -89,11 +128,11 @@ func main() {
 			</body>
 		</html>
 		`
-		w.Write([]byte(html))
+		_, _ = w.Write([]byte(html))
 	})
 
 	gorilla_adapter.InitAuth(ac, r)
 
 	fmt.Println("🚀 Listening on port :8080")
-	http.ListenAndServe(":8080", r)
+	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/examples/gorilla/gorilla.go
+++ b/examples/gorilla/gorilla.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	gorilla_adapter "github.com/AdrianTworek/go-auth/adapters/gorilla"
+	"github.com/AdrianTworek/go-auth/core"
+	"github.com/AdrianTworek/go-auth/examples"
+	"github.com/gorilla/mux"
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/github"
+	"github.com/markbates/goth/providers/google"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	examples.SetupEnv()
+}
+
+func main() {
+	r := mux.NewRouter()
+
+	ac, err := core.NewAuthClient(&core.AuthConfig{
+		Db: &core.DatabaseConfig{
+			Dsn: viper.GetString("DSN"),
+		},
+		Session: &core.SessionConfig{
+			MagicLinkSuccesfulRedirectURL: "http://localhost:8080/front/success",
+			MagicLinkFailedRedirectURL:    "http://localhost:8080/front/failed",
+			LoginAfterRegister:            true,
+		},
+		OAuth: &core.OAuthConfig{
+			Providers: []goth.Provider{
+				google.New(
+					viper.GetString("GOOGLE_CLIENT_ID"),
+					viper.GetString("GOOGLE_CLIENT_SECRET"),
+					fmt.Sprintf(
+						"%s/auth/oauth/callback?provider=google",
+						viper.GetString("BASE_URL"),
+					),
+					"email",
+					"profile",
+				),
+				github.New(
+					viper.GetString("GITHUB_CLIENT_ID"),
+					viper.GetString("GITHUB_CLIENT_SECRET"),
+					fmt.Sprintf(
+						"%s/auth/oauth/callback?provider=github",
+						viper.GetString("BASE_URL"),
+					),
+					"user:email",
+				),
+			},
+		},
+	})
+
+	if err != nil {
+		log.Fatalf("Error creating auth client: %v", err)
+	}
+
+	r.HandleFunc("/front/success", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		html := `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>My HTML Page</title>
+			</head>
+			<body>
+				<h1>Logged in successfully</h1>
+			</body>
+		</html>
+		`
+		w.Write([]byte(html))
+	})
+
+	r.HandleFunc("/front/failed", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		html := `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>My HTML Page</title>
+			</head>
+			<body>
+				<h1>Login Failed</h1>
+			</body>
+		</html>
+		`
+		w.Write([]byte(html))
+	})
+
+	gorilla_adapter.InitAuth(ac, r)
+
+	fmt.Println("🚀 Listening on port :8080")
+	http.ListenAndServe(":8080", r)
+}

--- a/examples/stdhttp/stdhttp.go
+++ b/examples/stdhttp/stdhttp.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/github"
+	"github.com/markbates/goth/providers/google"
+	"github.com/spf13/viper"
+
+	stdhttp_adapter "github.com/AdrianTworek/go-auth/adapters/stdhttp"
+	"github.com/AdrianTworek/go-auth/core"
+	"github.com/AdrianTworek/go-auth/examples"
+)
+
+func init() {
+	examples.SetupEnv()
+}
+
+func beforeLogin(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("this is from the before login hook", "event", event)
+	return nil
+}
+
+func afterLogin(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("this is from the after login hook", "event", event)
+	return &core.HookRedirect{
+		URL:    "http://localhost:8080/front/success",
+		Status: http.StatusFound,
+	}
+}
+
+func emailVerificationFailed(ctx context.Context, event *core.AuthEvent) error {
+	slog.Info("email verification failed")
+	return &core.HookRedirect{
+		URL:    "http://localhost:8080/front/failed",
+		Status: http.StatusFound,
+	}
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	ac, err := core.NewAuthClient(&core.AuthConfig{
+		Db: &core.DatabaseConfig{
+			Dsn: viper.GetString("DSN"),
+		},
+		Session: &core.SessionConfig{
+			MagicLinkSuccessfulRedirectURL: "http://localhost:8080/front/success",
+			MagicLinkFailedRedirectURL:     "http://localhost:8080/front/failed",
+			LoginAfterRegister:             true,
+			// This example runs over plain HTTP, so disable Secure to let the
+			// browser send the session cookie. Remove this in production (HTTPS).
+			CookieSecure: core.Ptr(false),
+		},
+		OAuth: &core.OAuthConfig{
+			Providers: []goth.Provider{
+				google.New(
+					viper.GetString("GOOGLE_CLIENT_ID"),
+					viper.GetString("GOOGLE_CLIENT_SECRET"),
+					fmt.Sprintf(
+						"%s/auth/oauth/callback?provider=google",
+						viper.GetString("BASE_URL"),
+					),
+					"email",
+					"profile",
+				),
+				github.New(
+					viper.GetString("GITHUB_CLIENT_ID"),
+					viper.GetString("GITHUB_CLIENT_SECRET"),
+					fmt.Sprintf(
+						"%s/auth/oauth/callback?provider=github",
+						viper.GetString("BASE_URL"),
+					),
+					"user:email",
+				),
+			},
+		},
+		SessionSecret: viper.GetString("SESSION_SECRET"),
+		BaseURL:       "http://localhost:8080",
+		Hooks: &core.HookMap{
+			core.EventBeforeLogin: core.HookList{
+				beforeLogin,
+			},
+			core.EventAfterLogin: core.HookList{
+				afterLogin,
+			},
+			core.EventEmailVerificationFailed: core.HookList{
+				emailVerificationFailed,
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Error creating auth client: %v", err)
+	}
+
+	mux.HandleFunc("GET /front/success", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		html := `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>My HTML Page</title>
+			</head>
+			<body>
+				<h1>Logged in successfully</h1>
+			</body>
+		</html>
+		`
+		_, _ = w.Write([]byte(html))
+	})
+
+	mux.HandleFunc("GET /front/failed", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		html := `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>My HTML Page</title>
+			</head>
+			<body>
+				<h1>Login Failed</h1>
+			</body>
+		</html>
+		`
+		_, _ = w.Write([]byte(html))
+	})
+
+	stdhttp_adapter.InitAuth(ac, mux)
+
+	fmt.Println("🚀 Listening on port :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/mux v1.7.4 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.1.1 h1:YMDmfaK68mUixINzY/XjscuJ47uXFWSSHzFbBQM0PrE=


### PR DESCRIPTION
Adds two new framework integrations alongside the existing chi/echo/gin/fiber ones:
- gorilla/mux — adapter + runnable example
- net/http (standard library) — adapter + runnable example, using Go 1.22+ ServeMux method/pattern routing (no third-party router)