### PR TITLE
refactor(adapters): gate magic-link routes on CanLoginWithMagicLink

### DIFF
--- a/adapters/chi/chi_adapter.go
+++ b/adapters/chi/chi_adapter.go
@@ -34,12 +34,14 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 			r.Get("/oauth/callback", ac.OAuthCallbackHandler())
 		}
 
-		r.Route("/magic-link", func(r chi.Router) {
-			r.Post("/", ac.SendMagicLinkHandler())
-			r.Get("/{token}", func(w http.ResponseWriter, r *http.Request) {
-				ac.CompleteMagicLinkSignInHandler(&ChiParamExtractor{Req: r})(w, r)
+		if ac.CanLoginWithMagicLink() {
+			r.Route("/magic-link", func(r chi.Router) {
+				r.Post("/", ac.SendMagicLinkHandler())
+				r.Get("/{token}", func(w http.ResponseWriter, r *http.Request) {
+					ac.CompleteMagicLinkSignInHandler(&ChiParamExtractor{Req: r})(w, r)
+				})
 			})
-		})
+		}
 
 		r.Route("/reset-password", func(r chi.Router) {
 			r.Post("/", ac.SendPasswordResetLinkHandler())

--- a/adapters/echo/echo_adapter.go
+++ b/adapters/echo/echo_adapter.go
@@ -35,10 +35,12 @@ func InitAuth(ac *core.AuthClient, r *echo.Echo) {
 		publicRouter.GET("/oauth/callback", echo.WrapHandler(ac.OAuthCallbackHandler()))
 	}
 
-	publicRouter.POST("/magic-link", echo.WrapHandler(ac.SendMagicLinkHandler()))
-	publicRouter.GET("/magic-link/:token", func(c echo.Context) error {
-		return echo.WrapHandler(ac.CompleteMagicLinkSignInHandler(&EchoParamExtractor{Ctx: c}))(c)
-	})
+	if ac.CanLoginWithMagicLink() {
+		publicRouter.POST("/magic-link", echo.WrapHandler(ac.SendMagicLinkHandler()))
+		publicRouter.GET("/magic-link/:token", func(c echo.Context) error {
+			return echo.WrapHandler(ac.CompleteMagicLinkSignInHandler(&EchoParamExtractor{Ctx: c}))(c)
+		})
+	}
 
 	publicRouter.POST("/reset-password", echo.WrapHandler(ac.SendPasswordResetLinkHandler()))
 	publicRouter.PUT("/reset-password/:token", func(c echo.Context) error {

--- a/adapters/fiber/fiber_adapter.go
+++ b/adapters/fiber/fiber_adapter.go
@@ -33,11 +33,13 @@ func InitAuth(ac *core.AuthClient, r *fiber.App) {
 		publicRouter.Get("/oauth/callback", adaptor.HTTPHandlerFunc(ac.OAuthCallbackHandler()))
 	}
 
-	publicMagicLinkRouter := publicRouter.Group("/magic-link")
-	publicMagicLinkRouter.Post("/", adaptor.HTTPHandlerFunc(ac.SendMagicLinkHandler()))
-	publicMagicLinkRouter.Get("/:token", func(c *fiber.Ctx) error {
-		return adaptor.HTTPHandlerFunc(ac.CompleteMagicLinkSignInHandler(&FiberParamExtractor{Ctx: c}))(c)
-	})
+	if ac.CanLoginWithMagicLink() {
+		publicMagicLinkRouter := publicRouter.Group("/magic-link")
+		publicMagicLinkRouter.Post("/", adaptor.HTTPHandlerFunc(ac.SendMagicLinkHandler()))
+		publicMagicLinkRouter.Get("/:token", func(c *fiber.Ctx) error {
+			return adaptor.HTTPHandlerFunc(ac.CompleteMagicLinkSignInHandler(&FiberParamExtractor{Ctx: c}))(c)
+		})
+	}
 
 	publicResetPasswordRouter := publicRouter.Group("/reset-password")
 	publicResetPasswordRouter.Post("/", adaptor.HTTPHandlerFunc(ac.SendPasswordResetLinkHandler()))

--- a/adapters/gin/gin_adapter.go
+++ b/adapters/gin/gin_adapter.go
@@ -33,11 +33,13 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 		publicRouter.GET("/oauth/callback", gin.WrapH(ac.OAuthCallbackHandler()))
 	}
 
-	publicMagicLinkRouter := publicRouter.Group("/magic-link")
-	publicMagicLinkRouter.POST("/", gin.WrapH(ac.SendMagicLinkHandler()))
-	publicMagicLinkRouter.GET("/:token", func(c *gin.Context) {
-		ac.CompleteMagicLinkSignInHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
-	})
+	if ac.CanLoginWithMagicLink() {
+		publicMagicLinkRouter := publicRouter.Group("/magic-link")
+		publicMagicLinkRouter.POST("/", gin.WrapH(ac.SendMagicLinkHandler()))
+		publicMagicLinkRouter.GET("/:token", func(c *gin.Context) {
+			ac.CompleteMagicLinkSignInHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
+		})
+	}
 
 	publicResetPasswordRouter := publicRouter.Group("/reset-password")
 	publicResetPasswordRouter.POST("/", gin.WrapH(ac.SendPasswordResetLinkHandler()))

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -36,11 +36,13 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 		publicRouter.HandleFunc("/oauth/callback", ac.OAuthCallbackHandler()).Methods("GET")
 	}
 
-	publicRouter.HandleFunc("/magic-link", ac.SendMagicLinkHandler()).Methods("POST")
-	publicRouter.HandleFunc("/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		ac.CompleteMagicLinkSignInHandler(&GorillaParamExtractor{Vars: vars}).ServeHTTP(w, r)
-	}).Methods("GET")
+	if ac.CanLoginWithMagicLink() {
+		publicRouter.HandleFunc("/magic-link", ac.SendMagicLinkHandler()).Methods("POST")
+		publicRouter.HandleFunc("/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
+			vars := mux.Vars(r)
+			ac.CompleteMagicLinkSignInHandler(&GorillaParamExtractor{Vars: vars}).ServeHTTP(w, r)
+		}).Methods("GET")
+	}
 
 	publicRouter.HandleFunc("/reset-password", ac.SendPasswordResetLinkHandler()).Methods("POST")
 	publicRouter.HandleFunc("/reset-password/{token}", func(w http.ResponseWriter, r *http.Request) {

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -32,10 +32,12 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 		mux.Handle("GET /auth/oauth/callback", ac.OAuthCallbackHandler())
 	}
 
-	mux.Handle("POST /auth/magic-link", ac.SendMagicLinkHandler())
-	mux.HandleFunc("GET /auth/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
-		ac.CompleteMagicLinkSignInHandler(&StdHTTPParamExtractor{Req: r})(w, r)
-	})
+	if ac.CanLoginWithMagicLink() {
+		mux.Handle("POST /auth/magic-link", ac.SendMagicLinkHandler())
+		mux.HandleFunc("GET /auth/magic-link/{token}", func(w http.ResponseWriter, r *http.Request) {
+			ac.CompleteMagicLinkSignInHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+		})
+	}
 
 	mux.Handle("POST /auth/reset-password", ac.SendPasswordResetLinkHandler())
 	mux.HandleFunc("PUT /auth/reset-password/{token}", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Magic-link routes were always registered while OAuth routes were already gated with CanLoginWithOAuth, so the two features were handled inconsistently. Register the magic-link routes only when magic link is configured, mirroring the OAuth pattern, so unconfigured endpoints return 404 instead of a 500. The in-handler guards are kept as defense in depth.