### PR TITLE
ci: add Dependabot config and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Go module dependencies
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'build'
+      prefix-development: 'build'
+    groups:
+      go-minor-patch:
+        update-types: ['minor', 'patch']
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'ci'
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -17,10 +17,10 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -31,7 +31,7 @@ jobs:
         run: go build ./...
 
       - name: Lint and format check
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## What

- Add `.github/dependabot.yml` covering two ecosystems:
  - **`gomod`** — weekly, minor/patch updates grouped into a single PR, majors kept separate, `build(deps):` commit prefix
  - **`github-actions`** — weekly, all bumps grouped, `ci(deps):` commit prefix
- Pin all workflow actions to immutable commit SHAs (with `# vX.Y.Z` comments), keeping the same major versions:
  - `release-please-action` → `v4.4.1`
  - `actions/checkout` → `v4.3.1`
  - `actions/setup-go` → `v5.6.0`
  - `golangci-lint-action` → `v9.2.1`

## Why

- SHA-pinned actions are immutable, closing a supply-chain gap (mutable tags can be re-pointed). Relevant for an auth library.
- The `# vX.Y.Z` comments let Dependabot bump both the SHA and the comment automatically, so pinning stays maintenance-free.
- Commit prefixes are `build`/`ci`, which are non-releasing under the release-please config — dependency bumps won't each cut a release.

## Manual follow-up (not in this PR)

Enable **Dependabot alerts + security updates** in **Settings → Code security** for CVE-driven PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)