### PR TITLE
ci: make Go dependency bumps releasing commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     commit-message:
-      prefix: 'build'
-      prefix-development: 'build'
+      # `fix` so dependency bumps are releasing commits — release-please
+      # rolls them into a patch release automatically (no manual Release-As).
+      prefix: 'fix'
+      prefix-development: 'fix'
     groups:
       go-minor-patch:
         update-types: ['minor', 'patch']


### PR DESCRIPTION
## What
Change the **gomod** Dependabot commit prefix from `build` to `fix`.

## Why
`build`/`ci`/`chore` are non-releasing commit types, so dependency bumps
never triggered a release — they required a manual `Release-As` nudge
(see #37). With `fix(deps):`, dependency updates become patch-level
releasing commits, and release-please automatically rolls them into its
single rolling release PR. No more manual step.

GitHub Actions bumps stay `ci:` on purpose — they're CI-only and never
reach module consumers, so they shouldn't cut releases.

## Trade-offs
- Dependency bumps will appear under **Bug Fixes** in the changelog
  (cosmetic; a dedicated "Dependencies" section isn't possible without
  losing the version bump, since release-please only releases on
  `feat`/`fix`/breaking).
- GitHub-managed **security** PRs may still arrive as `chore(deps):` and
  won't trigger a release on their own, but get swept into the next
  `fix(deps):` release.

## Net result
Weekly grouped dep bumps → `fix(deps):` → release-please opens/updates one
rolling release PR → merge it to ship. Final merge stays manual by design
(human review of the changelog before tagging an auth library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)