### PR TITLE
feat(core): configurable session and token durations

### DIFF
--- a/core/auth_client.go
+++ b/core/auth_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
@@ -20,6 +21,17 @@ type AuthClient struct {
 	store      *store.Storage
 	hookStore  *HookStore
 	cookieOpts auth.CookieOptions
+	durations  resolvedDurations
+}
+
+// resolvedDurations holds the session and token lifetimes for an AuthClient with
+// all defaults already applied, so handlers and middleware never read raw config.
+type resolvedDurations struct {
+	session           time.Duration
+	refreshThreshold  time.Duration
+	emailVerification time.Duration
+	passwordReset     time.Duration
+	magicLink         time.Duration
 }
 
 // Checks if mailer is configured and magic link redirect urls are also provided
@@ -86,6 +98,40 @@ func resolveCookieOptions(s *SessionConfig) auth.CookieOptions {
 	return opts
 }
 
+// resolveDurations builds the effective session and token lifetimes, applying the
+// library defaults for anything the consumer left at zero. The slide threshold
+// defaults to half the (resolved) session duration.
+func resolveDurations(s *SessionConfig, t *TokenConfig) resolvedDurations {
+	d := resolvedDurations{
+		session:           auth.DefaultSessionDuration,
+		emailVerification: auth.DefaultTokenDuration,
+		passwordReset:     auth.DefaultTokenDuration,
+		magicLink:         auth.DefaultTokenDuration,
+	}
+
+	if s != nil && s.Duration > 0 {
+		d.session = s.Duration
+	}
+	d.refreshThreshold = d.session / 2
+	if s != nil && s.RefreshThreshold > 0 {
+		d.refreshThreshold = s.RefreshThreshold
+	}
+
+	if t != nil {
+		if t.EmailVerification > 0 {
+			d.emailVerification = t.EmailVerification
+		}
+		if t.PasswordReset > 0 {
+			d.passwordReset = t.PasswordReset
+		}
+		if t.MagicLink > 0 {
+			d.magicLink = t.MagicLink
+		}
+	}
+
+	return d
+}
+
 func NewAuthClient(config *AuthConfig) (*AuthClient, error) {
 	// Default the session config so cookie/option resolution is always safe.
 	if config.Session == nil {
@@ -128,11 +174,43 @@ func NewAuthClient(config *AuthConfig) (*AuthClient, error) {
 		store:      store.NewStorage(db),
 		hookStore:  hookStore,
 		cookieOpts: resolveCookieOptions(config.Session),
+		durations:  resolveDurations(config.Session, config.Tokens),
 	}, nil
 }
 
-func (ac *AuthClient) newSessionCookie(token string) *http.Cookie {
-	return auth.NewSessionCookie(token, ac.cookieOpts)
+func (ac *AuthClient) newSessionCookie(token string, expiresAt time.Time) *http.Cookie {
+	return auth.NewSessionCookie(token, expiresAt, ac.cookieOpts)
+}
+
+// sessionExpiry returns the absolute expiry for a freshly created or refreshed
+// session, based on the configured session duration.
+func (ac *AuthClient) sessionExpiry() time.Time {
+	return time.Now().Add(ac.durations.session)
+}
+
+// tokenExpiry returns the absolute expiry for an emailed single-use token of the
+// given intent, based on the configured per-intent token durations.
+func (ac *AuthClient) tokenExpiry(intent auth.VerificationIntent) time.Time {
+	var d time.Duration
+	switch intent {
+	case auth.EmailVerificationIntent:
+		d = ac.durations.emailVerification
+	case auth.PasswordResetIntent:
+		d = ac.durations.passwordReset
+	case auth.MagicLinkIntent:
+		d = ac.durations.magicLink
+	default:
+		d = auth.DefaultTokenDuration
+	}
+	return time.Now().Add(d)
+}
+
+// newVerification builds a verification row with its expiry already set from the
+// configured token durations, so callers can't accidentally leave it unset.
+func (ac *AuthClient) newVerification(intent auth.VerificationIntent, email, userID *auth.NullString) *store.Verification {
+	v := store.NewVerification(intent, email, userID)
+	v.ExpiresAt = ac.tokenExpiry(intent)
+	return v
 }
 
 func (ac *AuthClient) deleteSessionCookie() *http.Cookie {

--- a/core/config.go
+++ b/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/markbates/goth"
 
@@ -17,6 +18,7 @@ func Ptr[T any](v T) *T {
 type AuthConfig struct {
 	Db            *DatabaseConfig
 	Session       *SessionConfig
+	Tokens        *TokenConfig
 	OAuth         *OAuthConfig
 	Mailer        mailer.Mailer
 	Hooks         *HookMap
@@ -39,6 +41,20 @@ type DatabaseConfig struct {
 }
 
 type SessionConfig struct {
+	// Duration is how long a session is valid for. It sets both the session's
+	// server-side expiry and the session cookie's lifetime. When zero the library
+	// default is used.
+	//
+	// Default: 7 days
+	Duration time.Duration
+	// RefreshThreshold controls sliding sessions: on an authenticated request, when
+	// the session's remaining lifetime drops below this threshold, the middleware
+	// rotates the token and extends the session by a full Duration. When zero it
+	// defaults to half of Duration. Set it larger than Duration to refresh on every
+	// request, or leave it at the default for typical sliding behaviour.
+	//
+	// Default: Duration / 2
+	RefreshThreshold time.Duration
 	// LoginAfterRegister specifies whether to log in the user after registration.
 	//
 	// Default: false
@@ -86,4 +102,23 @@ type SessionConfig struct {
 	//
 	// Default: "session"
 	CookieName string
+}
+
+// TokenConfig sets how long the single-use tokens emailed to users stay valid.
+// Each field maps to one verification flow; a zero value falls back to the library
+// default. Keep these short — they bound the window an intercepted link is usable.
+type TokenConfig struct {
+	// EmailVerification is the lifetime of the email-verification link sent on
+	// registration.
+	//
+	// Default: 5 minutes
+	EmailVerification time.Duration
+	// PasswordReset is the lifetime of the password-reset link.
+	//
+	// Default: 5 minutes
+	PasswordReset time.Duration
+	// MagicLink is the lifetime of the passwordless magic-link sign-in link.
+	//
+	// Default: 5 minutes
+	MagicLink time.Duration
 }

--- a/core/duration_test.go
+++ b/core/duration_test.go
@@ -1,0 +1,98 @@
+package core
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AdrianTworek/go-auth/core/internal/auth"
+)
+
+func TestResolveDurations(t *testing.T) {
+	t.Run("applies defaults when config is nil", func(t *testing.T) {
+		d := resolveDurations(nil, nil)
+		assert.Equal(t, auth.DefaultSessionDuration, d.session)
+		assert.Equal(t, auth.DefaultSessionDuration/2, d.refreshThreshold)
+		assert.Equal(t, auth.DefaultTokenDuration, d.emailVerification)
+		assert.Equal(t, auth.DefaultTokenDuration, d.passwordReset)
+		assert.Equal(t, auth.DefaultTokenDuration, d.magicLink)
+	})
+
+	t.Run("defaults the refresh threshold to half the configured session duration", func(t *testing.T) {
+		d := resolveDurations(&SessionConfig{Duration: 2 * time.Hour}, nil)
+		assert.Equal(t, 2*time.Hour, d.session)
+		assert.Equal(t, time.Hour, d.refreshThreshold)
+	})
+
+	t.Run("honors an explicit refresh threshold", func(t *testing.T) {
+		d := resolveDurations(&SessionConfig{Duration: 2 * time.Hour, RefreshThreshold: 15 * time.Minute}, nil)
+		assert.Equal(t, 15*time.Minute, d.refreshThreshold)
+	})
+
+	t.Run("overrides only the token durations that are set", func(t *testing.T) {
+		d := resolveDurations(nil, &TokenConfig{
+			EmailVerification: time.Hour,
+			MagicLink:         10 * time.Minute,
+		})
+		assert.Equal(t, time.Hour, d.emailVerification)
+		assert.Equal(t, 10*time.Minute, d.magicLink)
+		assert.Equal(t, auth.DefaultTokenDuration, d.passwordReset) // left unset -> default
+	})
+
+	t.Run("treats zero values as unset and falls back to defaults", func(t *testing.T) {
+		d := resolveDurations(&SessionConfig{Duration: 0, RefreshThreshold: 0}, &TokenConfig{})
+		assert.Equal(t, auth.DefaultSessionDuration, d.session)
+		assert.Equal(t, auth.DefaultSessionDuration/2, d.refreshThreshold)
+		assert.Equal(t, auth.DefaultTokenDuration, d.emailVerification)
+	})
+}
+
+// Test_Integration_ConfiguredDurations verifies that a configured session duration
+// reaches both the session cookie and the persisted session row (and that the two
+// agree), and that a configured per-intent token duration reaches the verification
+// row — proving the durations are no longer hard-coded in the store layer.
+func Test_Integration_ConfiguredDurations(t *testing.T) {
+	c := NewTestAuthConfig(nil, &SessionConfig{
+		LoginAfterRegister: true,
+		Duration:           2 * time.Hour,
+	}, nil)
+	c.Tokens = &TokenConfig{EmailVerification: 30 * time.Minute}
+
+	app, dbCtr, db := SetupIntegration(t, c)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	userEmail := "durations@example.com"
+	app.mailer.On("SendVerificationEmail", userEmail, mock.Anything).Return(nil)
+
+	helper := newTestHelper(t, app)
+	_, rr := helper.CreateUser(userEmail, "Password123!")
+	require.Equal(t, http.StatusCreated, rr.Code)
+	app.mailer.AssertExpectations(t)
+
+	// The session cookie reflects the configured 2h duration, not the 7d default.
+	cookie := helper.GetSessionCookie(rr)
+	require.NotNil(t, cookie)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), cookie.Expires, time.Minute)
+
+	// The persisted session expiry matches the configured duration, and agrees with
+	// the cookie (modulo the column's one-second precision).
+	var dbSessionExpiry time.Time
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT s.expires_at FROM sessions s
+		 JOIN users u ON u.id = s.user_id
+		 WHERE u.email = $1`, userEmail,
+	).Scan(&dbSessionExpiry))
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), dbSessionExpiry, time.Minute)
+	assert.WithinDuration(t, cookie.Expires, dbSessionExpiry, 2*time.Second)
+
+	// The email-verification token reflects the configured 30m duration, not the 5m default.
+	var dbTokenExpiry time.Time
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT expires_at FROM verifications WHERE intent = 'email_verification'`,
+	).Scan(&dbTokenExpiry))
+	assert.WithinDuration(t, time.Now().Add(30*time.Minute), dbTokenExpiry, time.Minute)
+}

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -87,7 +87,9 @@ func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 
 		// Suppress auto-login when verification is required: the new user is unverified.
 		var token string
+		var sessionExpiresAt time.Time
 		if ac.config.Session.LoginAfterRegister && !ac.config.Session.RequireVerifiedEmail {
+			sessionExpiresAt = ac.sessionExpiry()
 			token, err = ac.store.Session.Create(
 				r.Context(),
 				tx,
@@ -95,7 +97,7 @@ func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 					UserID:    user.ID,
 					IPAddress: r.RemoteAddr,
 					UserAgent: r.UserAgent(),
-					ExpiresAt: time.Now().Add(24 * time.Hour),
+					ExpiresAt: sessionExpiresAt,
 				},
 			)
 			if err != nil {
@@ -107,7 +109,7 @@ func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 		verificationToken, err := ac.store.Verification.Create(
 			r.Context(),
 			tx,
-			store.NewVerification(
+			ac.newVerification(
 				auth.EmailVerificationIntent,
 				nil,
 				auth.NewNullString(user.ID),
@@ -131,7 +133,7 @@ func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 		}
 
 		if token != "" && ac.config.Session.LoginAfterRegister {
-			cookie := ac.newSessionCookie(token)
+			cookie := ac.newSessionCookie(token, sessionExpiresAt)
 			http.SetCookie(w, cookie)
 		}
 
@@ -220,6 +222,7 @@ func (ac *AuthClient) LoginHandler() http.HandlerFunc {
 			return
 		}
 
+		sessionExpiresAt := ac.sessionExpiry()
 		token, err := ac.store.Session.Create(
 			r.Context(),
 			nil,
@@ -227,7 +230,7 @@ func (ac *AuthClient) LoginHandler() http.HandlerFunc {
 				UserID:    user.ID,
 				IPAddress: r.RemoteAddr,
 				UserAgent: r.UserAgent(),
-				ExpiresAt: time.Now().Add(24 * time.Hour),
+				ExpiresAt: sessionExpiresAt,
 			},
 		)
 		if err != nil {
@@ -235,7 +238,7 @@ func (ac *AuthClient) LoginHandler() http.HandlerFunc {
 			return
 		}
 
-		cookie := ac.newSessionCookie(token)
+		cookie := ac.newSessionCookie(token, sessionExpiresAt)
 		http.SetCookie(w, cookie)
 
 		cont, err = ac.hookStore.Trigger(
@@ -483,7 +486,7 @@ func (ac *AuthClient) SendMagicLinkHandler() http.HandlerFunc {
 		verificationToken, err := ac.store.Verification.Create(
 			r.Context(),
 			tx,
-			store.NewVerification(
+			ac.newVerification(
 				auth.MagicLinkIntent,
 				auth.NewNullString(req.Email),
 				nil,
@@ -618,11 +621,12 @@ func (ac *AuthClient) CompleteMagicLinkSignInHandler(extractor ParamExtractor) h
 			}
 		}
 
+		sessionExpiresAt := ac.sessionExpiry()
 		sessionToken, err := ac.store.Session.Create(r.Context(), tx, &store.Session{
 			UserID:    user.ID,
 			IPAddress: r.RemoteAddr,
 			UserAgent: r.UserAgent(),
-			ExpiresAt: time.Now().Add(24 * time.Hour),
+			ExpiresAt: sessionExpiresAt,
 		})
 		if err != nil {
 			ac.FailedMagicLinkRedirect(w, r)
@@ -635,7 +639,7 @@ func (ac *AuthClient) CompleteMagicLinkSignInHandler(extractor ParamExtractor) h
 			return
 		}
 
-		cookie := ac.newSessionCookie(sessionToken)
+		cookie := ac.newSessionCookie(sessionToken, sessionExpiresAt)
 		http.SetCookie(w, cookie)
 
 		ac.SuccessMagicLinkRedirect(w, r)
@@ -693,7 +697,7 @@ func (ac *AuthClient) SendPasswordResetLinkHandler() http.HandlerFunc {
 		verificationToken, err := ac.store.Verification.Create(
 			r.Context(),
 			tx,
-			store.NewVerification(
+			ac.newVerification(
 				auth.PasswordResetIntent,
 				nil,
 				auth.NewNullString(user.ID),
@@ -908,6 +912,7 @@ func (ac *AuthClient) OAuthCallbackHandler() http.HandlerFunc {
 			}
 		}
 
+		sessionExpiresAt := ac.sessionExpiry()
 		token, err := ac.store.Session.Create(
 			r.Context(),
 			tx,
@@ -915,7 +920,7 @@ func (ac *AuthClient) OAuthCallbackHandler() http.HandlerFunc {
 				UserID:    user.ID,
 				IPAddress: r.RemoteAddr,
 				UserAgent: r.UserAgent(),
-				ExpiresAt: time.Now().Add(24 * time.Hour),
+				ExpiresAt: sessionExpiresAt,
 			},
 		)
 		if err != nil {
@@ -927,7 +932,7 @@ func (ac *AuthClient) OAuthCallbackHandler() http.HandlerFunc {
 			return
 		}
 
-		http.SetCookie(w, ac.newSessionCookie(token))
+		http.SetCookie(w, ac.newSessionCookie(token, sessionExpiresAt))
 
 		cont, err = ac.hookStore.Trigger(
 			r.Context(),

--- a/core/internal/auth/auth.go
+++ b/core/internal/auth/auth.go
@@ -16,12 +16,15 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-var (
-	SessionDuration         = 7 * 24 * time.Hour
-	SessionRefreshThreshold = SessionDuration / 2
-)
-
 const (
+	// DefaultSessionDuration is the fallback session lifetime used when
+	// SessionConfig.Duration is left unset.
+	DefaultSessionDuration = 7 * 24 * time.Hour
+	// DefaultTokenDuration is the fallback lifetime for emailed single-use tokens
+	// (email verification, password reset, magic link) when the matching
+	// TokenConfig field is left unset.
+	DefaultTokenDuration = 5 * time.Minute
+
 	SessionTokenBytes = 32
 	EmailTokenBytes   = 64
 )
@@ -248,8 +251,8 @@ func baseCookie(token string, expiresAt time.Time, opts CookieOptions) *http.Coo
 	}
 }
 
-func NewSessionCookie(token string, opts CookieOptions) *http.Cookie {
-	return baseCookie(token, time.Now().Add(SessionDuration), opts)
+func NewSessionCookie(token string, expiresAt time.Time, opts CookieOptions) *http.Cookie {
+	return baseCookie(token, expiresAt, opts)
 }
 
 func DeleteSessionCookie(opts CookieOptions) *http.Cookie {

--- a/core/internal/store/session.go
+++ b/core/internal/store/session.go
@@ -38,8 +38,9 @@ func (s *SessionStore) Create(ctx context.Context, tx *sqlx.Tx, session *Session
 		return "", err
 	}
 	// Store only the hash; the raw token is returned to the caller (set as the cookie).
+	// ExpiresAt is provided by the caller (AuthClient) so session-lifetime policy
+	// lives in one place rather than being overridden here.
 	session.Token = auth.HashToken(token)
-	session.ExpiresAt = time.Now().Add(auth.SessionDuration)
 
 	if tx != nil {
 		_, err = tx.NamedExecContext(ctx, query, session)
@@ -96,7 +97,7 @@ func (s *SessionStore) Delete(ctx context.Context, tx *sqlx.Tx, token string) er
 	return nil
 }
 
-func (s *SessionStore) Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string) (string, error) {
+func (s *SessionStore) Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string, expiresAt time.Time) (string, error) {
 	query := `
 		UPDATE sessions
 		SET token = $1, expires_at = $2
@@ -111,7 +112,7 @@ func (s *SessionStore) Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string
 		return "", err
 	}
 
-	_, err = s.db.ExecContext(ctx, query, auth.HashToken(token), time.Now().Add(auth.SessionDuration), auth.HashToken(oldToken))
+	_, err = s.db.ExecContext(ctx, query, auth.HashToken(token), expiresAt, auth.HashToken(oldToken))
 	if err != nil {
 		return "", err
 	}

--- a/core/internal/store/store.go
+++ b/core/internal/store/store.go
@@ -26,7 +26,7 @@ type Storage struct {
 	Session interface {
 		Create(ctx context.Context, tx *sqlx.Tx, session *Session) (token string, err error)
 		Validate(ctx context.Context, tx *sqlx.Tx, token string) (*Session, error)
-		Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string) (string, error)
+		Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string, expiresAt time.Time) (string, error)
 		Delete(ctx context.Context, tx *sqlx.Tx, token string) error
 		DeleteForUser(ctx context.Context, tx *sqlx.Tx, userID string) error
 		DeleteExpired(ctx context.Context) error

--- a/core/internal/store/verification.go
+++ b/core/internal/store/verification.go
@@ -11,8 +11,6 @@ import (
 	"github.com/AdrianTworek/go-auth/core/internal/auth"
 )
 
-var TokenDuration = 5 * time.Minute
-
 type Verification struct {
 	ID        string                  `json:"id" db:"id"`
 	Intent    auth.VerificationIntent `json:"intent" db:"intent"`
@@ -56,8 +54,9 @@ func (s *VerificationStore) Create(ctx context.Context, tx *sqlx.Tx, verificatio
 		return "", err
 	}
 	// Store only the hash; the raw token is returned to the caller (emailed to the user).
+	// ExpiresAt is provided by the caller (AuthClient) so token-lifetime policy lives
+	// in one place rather than being overridden here.
 	verification.Value = auth.HashToken(verificationToken)
-	verification.ExpiresAt = time.Now().Add(TokenDuration)
 
 	if tx != nil {
 		_, err = tx.NamedExecContext(ctx, query, verification)

--- a/core/middleware.go
+++ b/core/middleware.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"time"
-
-	"github.com/AdrianTworek/go-auth/core/internal/auth"
 )
 
 func (ac *AuthClient) AuthMiddleware() func(next http.Handler) http.Handler {
@@ -27,14 +25,15 @@ func (ac *AuthClient) AuthMiddleware() func(next http.Handler) http.Handler {
 			// tracked so downstream handlers (e.g. logout) act on the current token
 			// even after a rotation.
 			effectiveToken := token.Value
-			if time.Until(session.ExpiresAt) < auth.SessionRefreshThreshold {
-				newToken, err := ac.store.Session.Refresh(r.Context(), nil, token.Value)
+			if time.Until(session.ExpiresAt) < ac.durations.refreshThreshold {
+				newExpiresAt := ac.sessionExpiry()
+				newToken, err := ac.store.Session.Refresh(r.Context(), nil, token.Value, newExpiresAt)
 				if err != nil {
 					serverError(w, r, err)
 					return
 				}
 
-				http.SetCookie(w, ac.newSessionCookie(newToken))
+				http.SetCookie(w, ac.newSessionCookie(newToken, newExpiresAt))
 				effectiveToken = newToken
 			}
 

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -95,6 +95,7 @@ func (a *TestApp) Router() *chi.Mux {
 		},
 		Mailer:        a.mailer,
 		Session:       a.config.Session,
+		Tokens:        a.config.Tokens,
 		OAuth:         a.config.OAuth,
 		Hooks:         a.config.Hooks,
 		BaseURL:       a.config.BaseURL,


### PR DESCRIPTION
## What

Makes session and emailed-token lifetimes configurable, and fixes the long-standing 24h-vs-7d session-expiry inconsistency.

### New config
- `SessionConfig.Duration` — session lifetime; sets both the server-side expiry and the cookie. Default: **7 days**.
- `SessionConfig.RefreshThreshold` — sliding-session window; the middleware rotates the token when the remaining lifetime drops below it. Default: **`Duration / 2`**.
- `TokenConfig` — per-intent lifetimes for emailed single-use tokens: `EmailVerification`, `PasswordReset`, `MagicLink`. Default: **5 minutes** each.

All fields are optional; zero falls back to the existing defaults, so **behaviour is unchanged unless configured**.

```go
core.NewAuthClient(&core.AuthConfig{
    Session: &core.SessionConfig{Duration: 30 * 24 * time.Hour, RefreshThreshold: 7 * 24 * time.Hour},
    Tokens:  &core.TokenConfig{EmailVerification: time.Hour, PasswordReset: 15 * time.Minute, MagicLink: 10 * time.Minute},
    // ...
})
```

## Why / the fix

Previously `SessionStore.Create` and `VerificationStore.Create` **overrode** the caller's `ExpiresAt` with a hard-coded global. Handlers passed `24h`, but the store silently replaced it with `7d` — so the handler code misrepresented the real lifetime.

This moves lifetime policy to the `AuthClient` (resolved once at construction) and makes the store respect the caller's `ExpiresAt`. Side benefit: the cookie `Expires` and DB `expires_at` now derive from a single timestamp, so they always agree.

The former mutable globals (`auth.SessionDuration`, `store.TokenDuration`, …) are now `auth.DefaultSessionDuration` / `auth.DefaultTokenDuration` constants used only as fallbacks — no package-level mutable duration state.

## Tests
- `TestResolveDurations` — unit coverage of the resolution logic (defaults, threshold-defaults-to-half, per-intent overrides, zero-fallback).
- `Test_Integration_ConfiguredDurations` — proves a configured `Duration` reaches both the cookie and the DB row (and they match), and a configured token duration reaches the verification row.
- Full suite green; existing session-sliding test unaffected; `gofmt` clean; `golangci-lint` 0 issues.

## Follow-up (not in this PR)
The 5-minute email-verification default combined with the absence of a resend-verification endpoint is a lockout risk; planned for Phase 1 alongside a saner default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)