### PR TITLE
feat(core): add resend-verification endpoint

### DIFF
--- a/adapters/chi/chi_adapter.go
+++ b/adapters/chi/chi_adapter.go
@@ -30,6 +30,7 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 	r.Get(core.PathVerifyEmail, func(w http.ResponseWriter, r *http.Request) {
 		ac.VerifyEmailHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
+	r.Post(core.PathResendVerification, ac.ResendVerificationHandler())
 
 	if ac.CanLoginWithOAuth() {
 		r.Get(core.PathOAuthBegin, gothic.BeginAuthHandler)

--- a/adapters/conformance/conformance_test.go
+++ b/adapters/conformance/conformance_test.go
@@ -108,6 +108,7 @@ func Test_Conformance_AdaptersRegisterAllRoutes(t *testing.T) {
 		{http.MethodPost, core.PathRegister},
 		{http.MethodPost, core.PathLogin},
 		{http.MethodGet, withToken(core.PathVerifyEmail)},
+		{http.MethodPost, core.PathResendVerification},
 		{http.MethodGet, core.PathOAuthBegin + "?provider=github"},
 		{http.MethodGet, core.PathOAuthCallback},
 		{http.MethodPost, core.PathSendMagicLink},

--- a/adapters/echo/echo_adapter.go
+++ b/adapters/echo/echo_adapter.go
@@ -28,6 +28,7 @@ func InitAuth(ac *core.AuthClient, e *echo.Echo) {
 	e.GET(core.ColonParamPattern(core.PathVerifyEmail), func(c echo.Context) error {
 		return echo.WrapHandler(ac.VerifyEmailHandler(&EchoParamExtractor{Ctx: c}))(c)
 	})
+	e.POST(core.PathResendVerification, echo.WrapHandler(ac.ResendVerificationHandler()))
 
 	if ac.CanLoginWithOAuth() {
 		e.GET(core.PathOAuthBegin, func(c echo.Context) error {

--- a/adapters/fiber/fiber_adapter.go
+++ b/adapters/fiber/fiber_adapter.go
@@ -29,6 +29,7 @@ func InitAuth(ac *core.AuthClient, app *fiber.App) {
 	app.Get(core.ColonParamPattern(core.PathVerifyEmail), func(c *fiber.Ctx) error {
 		return adaptor.HTTPHandlerFunc(ac.VerifyEmailHandler(&FiberParamExtractor{Ctx: c}))(c)
 	})
+	app.Post(core.PathResendVerification, adaptor.HTTPHandlerFunc(ac.ResendVerificationHandler()))
 
 	if ac.CanLoginWithOAuth() {
 		app.Get(core.PathOAuthBegin, adaptor.HTTPHandlerFunc(gothic.BeginAuthHandler))

--- a/adapters/gin/gin_adapter.go
+++ b/adapters/gin/gin_adapter.go
@@ -28,6 +28,7 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 	r.GET(core.ColonParamPattern(core.PathVerifyEmail), func(c *gin.Context) {
 		ac.VerifyEmailHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
 	})
+	r.POST(core.PathResendVerification, gin.WrapH(ac.ResendVerificationHandler()))
 
 	if ac.CanLoginWithOAuth() {
 		r.GET(core.PathOAuthBegin, gin.WrapF(gothic.BeginAuthHandler))

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -30,6 +30,7 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 	r.HandleFunc(core.PathVerifyEmail, func(w http.ResponseWriter, r *http.Request) {
 		ac.VerifyEmailHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
 	}).Methods(http.MethodGet)
+	r.Handle(core.PathResendVerification, ac.ResendVerificationHandler()).Methods(http.MethodPost)
 
 	if ac.CanLoginWithOAuth() {
 		r.HandleFunc(core.PathOAuthBegin, gothic.BeginAuthHandler).Methods(http.MethodGet)

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -27,6 +27,7 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 	mux.HandleFunc("GET "+core.PathVerifyEmail, func(w http.ResponseWriter, r *http.Request) {
 		ac.VerifyEmailHandler(&StdHTTPParamExtractor{Req: r})(w, r)
 	})
+	mux.Handle("POST "+core.PathResendVerification, ac.ResendVerificationHandler())
 
 	if ac.CanLoginWithOAuth() {
 		mux.HandleFunc("GET "+core.PathOAuthBegin, gothic.BeginAuthHandler)

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -17,6 +17,11 @@ import (
 // not the email is registered, so the response never reveals account existence.
 const genericResetMessage = "If an account with that email exists, a password reset link has been sent."
 
+// genericVerificationMessage is returned by the resend-verification endpoint for
+// every outcome, so the response never reveals whether the email is registered or
+// whether it is already verified.
+const genericVerificationMessage = "If an account with that email exists and is unverified, a verification link has been sent."
+
 func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 	type registerRequest struct {
 		Email           string `json:"email" validate:"required,min=3,max=255,email"`
@@ -438,6 +443,86 @@ func (ac *AuthClient) VerifyEmailHandler(extractor ParamExtractor) http.HandlerF
 		}
 
 		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Email verified successfully"})
+	}
+}
+
+// ResendVerificationHandler re-issues an email-verification link for an account that
+// registered but never verified (e.g. the original token expired). It is the recovery
+// path for the otherwise dead-ended unverified user. Every outcome returns the same
+// generic 200 so the endpoint can't be used to enumerate accounts or learn which
+// addresses are already verified.
+func (ac *AuthClient) ResendVerificationHandler() http.HandlerFunc {
+	type request struct {
+		Email string `json:"email" validate:"required,email"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req request
+		if err := readAndValidateJSON(w, r, &req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// respond is used for every non-error outcome so registered, unregistered and
+		// already-verified addresses are indistinguishable from the response.
+		respond := func() {
+			writeJSONResponse(w, http.StatusOK, map[string]any{"message": genericVerificationMessage})
+		}
+
+		user, err := ac.store.User.GetByEmail(r.Context(), nil, req.Email)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				respond()
+				return
+			}
+			serverError(w, r, err)
+			return
+		}
+
+		// Nothing to do for an already-verified account, but don't reveal that.
+		if user.EmailVerified {
+			respond()
+			return
+		}
+
+		tx, err := ac.store.Transaction.Begin()
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+		defer func(tx *sqlx.Tx) {
+			if err != nil {
+				if rbErr := ac.store.Transaction.Rollback(tx); rbErr != nil {
+					slog.Error("rollback error", "error", rbErr)
+				}
+			}
+		}(tx)
+
+		verificationToken, err := ac.store.Verification.Create(
+			r.Context(),
+			tx,
+			ac.newVerification(
+				auth.EmailVerificationIntent,
+				nil,
+				auth.NewNullString(user.ID),
+			),
+		)
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.config.Mailer.SendVerificationEmail(user.Email, verificationToken); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.store.Transaction.Commit(tx); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		respond()
 	}
 }
 

--- a/core/resend_verification_test.go
+++ b/core/resend_verification_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func postResendVerification(t *testing.T, app *TestApp, email string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"email": email})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, PathResendVerification, bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	return rr
+}
+
+func assertGenericVerificationMessage(t *testing.T, rr *httptest.ResponseRecorder) {
+	t.Helper()
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	data, ok := resp["data"].(map[string]any)
+	require.True(t, ok, "response missing data object: %s", rr.Body.String())
+	assert.Equal(t, genericVerificationMessage, data["message"])
+}
+
+// Test_Integration_ResendVerificationResendsForUnverifiedUser verifies that an
+// unverified account gets a fresh verification email and a new token row.
+func Test_Integration_ResendVerificationResendsForUnverifiedUser(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	email := TestUserData[UnverifiedUser].Email
+	app.mailer.On("SendVerificationEmail", email, mock.Anything).Return(nil)
+
+	rr := postResendVerification(t, app, email)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assertGenericVerificationMessage(t, rr)
+	app.mailer.AssertExpectations(t)
+
+	var count int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM verifications v
+		 JOIN users u ON u.id = v.user_id
+		 WHERE u.email = $1 AND v.intent = 'email_verification'`, email,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "a verification token should have been created")
+}
+
+// Test_Integration_ResendVerificationSkipsVerifiedUser verifies that an already-verified
+// account gets the generic response but no email.
+func Test_Integration_ResendVerificationSkipsVerifiedUser(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := postResendVerification(t, app, TestUserData[DefaultUser].Email) // already verified
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assertGenericVerificationMessage(t, rr)
+	app.mailer.AssertNotCalled(t, "SendVerificationEmail", mock.Anything, mock.Anything)
+}
+
+// Test_Integration_ResendVerificationUnknownEmailIsGeneric verifies that an unregistered
+// (but well-formed) email gets the same generic 200 and sends nothing, so the response
+// can't be used to enumerate accounts.
+func Test_Integration_ResendVerificationUnknownEmailIsGeneric(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := postResendVerification(t, app, "does_not_exist@example.com")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assertGenericVerificationMessage(t, rr)
+	app.mailer.AssertNotCalled(t, "SendVerificationEmail", mock.Anything, mock.Anything)
+}
+
+func Test_Integration_ResendVerificationInvalidEmail(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := postResendVerification(t, app, "not-an-email")
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/core/routes.go
+++ b/core/routes.go
@@ -9,17 +9,18 @@ import "strings"
 // Patterns use the "{name}" placeholder for path parameters; adapters for routers that
 // use ":name" syntax (gin, echo, fiber) translate with ColonParamPattern.
 const (
-	PathRegister          = "/auth/register"
-	PathLogin             = "/auth/login"
-	PathLogout            = "/auth/logout"
-	PathMe                = "/auth/me"
-	PathVerifyEmail       = "/auth/verify/{token}"
-	PathOAuthBegin        = "/auth/oauth"
-	PathOAuthCallback     = "/auth/oauth/callback"
-	PathSendMagicLink     = "/auth/magic-link"
-	PathMagicLink         = "/auth/magic-link/{token}"
-	PathSendPasswordReset = "/auth/reset-password"         // #nosec G101 -- URL path, not a credential
-	PathPasswordReset     = "/auth/reset-password/{token}" // #nosec G101 -- URL path, not a credential
+	PathRegister           = "/auth/register"
+	PathLogin              = "/auth/login"
+	PathLogout             = "/auth/logout"
+	PathMe                 = "/auth/me"
+	PathResendVerification = "/auth/resend-verification"
+	PathVerifyEmail        = "/auth/verify/{token}"
+	PathOAuthBegin         = "/auth/oauth"
+	PathOAuthCallback      = "/auth/oauth/callback"
+	PathSendMagicLink      = "/auth/magic-link"
+	PathMagicLink          = "/auth/magic-link/{token}"
+	PathSendPasswordReset  = "/auth/reset-password"         // #nosec G101 -- URL path, not a credential
+	PathPasswordReset      = "/auth/reset-password/{token}" // #nosec G101 -- URL path, not a credential
 )
 
 // ColonParamPattern converts a canonical "{name}" path pattern to the ":name" form

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -115,6 +115,7 @@ func (a *TestApp) Router() *chi.Mux {
 	r.Get(PathVerifyEmail, func(w http.ResponseWriter, r *http.Request) {
 		ac.VerifyEmailHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
+	r.Post(PathResendVerification, ac.ResendVerificationHandler())
 
 	r.Post(PathSendMagicLink, ac.SendMagicLinkHandler())
 	r.Get(PathMagicLink, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
First Phase 1 endpoint, and the fix for the lockout we flagged earlier: a user who registers but never verifies their email had no way to get a new link once the token expired (5 minutes by default), which is a hard lockout when `RequireVerifiedEmail` is on.

## What

`POST /auth/resend-verification` → `ResendVerificationHandler`. Given an email, it re-issues a verification link for an **unverified** account.

Anti-enumeration: every outcome returns the same generic `200`, mirroring the existing `SendPasswordResetLinkHandler`:

| Input | Behaviour |
|---|---|
| Unverified account | new token + verification email |
| Already-verified account | no email |
| Unknown (well-formed) address | no email |
| Malformed email | `400` |

## How it rides on the route-constants work (#44)

First endpoint added since the constants + conformance work, and it shows the payoff: **one handler, one `core.PathResendVerification` constant, one line per adapter**, and the conformance test picks up the new route across all six frameworks automatically (now 12 routes × 6 adapters).

## Tests
- `Test_Integration_ResendVerification*` — the four rows above, asserting status, the generic message, mailer called / not-called, and that a token row is actually created for the unverified case.
- Full suite green; conformance green; `go vet` / `gofmt` / `golangci-lint` clean.

## Follow-up (not here)
Like the other send-email endpoints, this one wants **rate limiting** (email-bombing protection) — tracked as a separate Phase 1 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
