### PR TITLE
feat(core): add protected change-password and change-email handlers

### DIFF
--- a/adapters/chi/chi_adapter.go
+++ b/adapters/chi/chi_adapter.go
@@ -31,6 +31,9 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 		ac.VerifyEmailHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
 	r.Post(core.PathResendVerification, ac.ResendVerificationHandler())
+	r.Get(core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.ConfirmEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		r.Get(core.PathOAuthBegin, gothic.BeginAuthHandler)
@@ -51,4 +54,6 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 
 	r.Method(http.MethodGet, core.PathMe, mw(ac.GetMeHandler()))
 	r.Method(http.MethodPost, core.PathLogout, mw(ac.LogoutHandler()))
+	r.Method(http.MethodPost, core.PathChangePassword, mw(ac.ChangePasswordHandler()))
+	r.Method(http.MethodPost, core.PathChangeEmail, mw(ac.ChangeEmailHandler()))
 }

--- a/adapters/conformance/conformance_test.go
+++ b/adapters/conformance/conformance_test.go
@@ -115,8 +115,11 @@ func Test_Conformance_AdaptersRegisterAllRoutes(t *testing.T) {
 		{http.MethodGet, withToken(core.PathMagicLink)},
 		{http.MethodPost, core.PathSendPasswordReset},
 		{http.MethodPut, withToken(core.PathPasswordReset)},
+		{http.MethodGet, withToken(core.PathConfirmEmailChange)},
 		{http.MethodGet, core.PathMe},
 		{http.MethodPost, core.PathLogout},
+		{http.MethodPost, core.PathChangePassword},
+		{http.MethodPost, core.PathChangeEmail},
 	}
 
 	for name, probe := range probers {

--- a/adapters/echo/echo_adapter.go
+++ b/adapters/echo/echo_adapter.go
@@ -29,6 +29,9 @@ func InitAuth(ac *core.AuthClient, e *echo.Echo) {
 		return echo.WrapHandler(ac.VerifyEmailHandler(&EchoParamExtractor{Ctx: c}))(c)
 	})
 	e.POST(core.PathResendVerification, echo.WrapHandler(ac.ResendVerificationHandler()))
+	e.GET(core.ColonParamPattern(core.PathConfirmEmailChange), func(c echo.Context) error {
+		return echo.WrapHandler(ac.ConfirmEmailChangeHandler(&EchoParamExtractor{Ctx: c}))(c)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		e.GET(core.PathOAuthBegin, func(c echo.Context) error {
@@ -52,4 +55,6 @@ func InitAuth(ac *core.AuthClient, e *echo.Echo) {
 
 	e.GET(core.PathMe, echo.WrapHandler(mw(ac.GetMeHandler())))
 	e.POST(core.PathLogout, echo.WrapHandler(mw(ac.LogoutHandler())))
+	e.POST(core.PathChangePassword, echo.WrapHandler(mw(ac.ChangePasswordHandler())))
+	e.POST(core.PathChangeEmail, echo.WrapHandler(mw(ac.ChangeEmailHandler())))
 }

--- a/adapters/fiber/fiber_adapter.go
+++ b/adapters/fiber/fiber_adapter.go
@@ -30,6 +30,9 @@ func InitAuth(ac *core.AuthClient, app *fiber.App) {
 		return adaptor.HTTPHandlerFunc(ac.VerifyEmailHandler(&FiberParamExtractor{Ctx: c}))(c)
 	})
 	app.Post(core.PathResendVerification, adaptor.HTTPHandlerFunc(ac.ResendVerificationHandler()))
+	app.Get(core.ColonParamPattern(core.PathConfirmEmailChange), func(c *fiber.Ctx) error {
+		return adaptor.HTTPHandlerFunc(ac.ConfirmEmailChangeHandler(&FiberParamExtractor{Ctx: c}))(c)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		app.Get(core.PathOAuthBegin, adaptor.HTTPHandlerFunc(gothic.BeginAuthHandler))
@@ -50,4 +53,6 @@ func InitAuth(ac *core.AuthClient, app *fiber.App) {
 
 	app.Get(core.PathMe, adaptor.HTTPHandler(mw(ac.GetMeHandler())))
 	app.Post(core.PathLogout, adaptor.HTTPHandler(mw(ac.LogoutHandler())))
+	app.Post(core.PathChangePassword, adaptor.HTTPHandler(mw(ac.ChangePasswordHandler())))
+	app.Post(core.PathChangeEmail, adaptor.HTTPHandler(mw(ac.ChangeEmailHandler())))
 }

--- a/adapters/gin/gin_adapter.go
+++ b/adapters/gin/gin_adapter.go
@@ -29,6 +29,9 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 		ac.VerifyEmailHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
 	})
 	r.POST(core.PathResendVerification, gin.WrapH(ac.ResendVerificationHandler()))
+	r.GET(core.ColonParamPattern(core.PathConfirmEmailChange), func(c *gin.Context) {
+		ac.ConfirmEmailChangeHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		r.GET(core.PathOAuthBegin, gin.WrapF(gothic.BeginAuthHandler))
@@ -49,4 +52,6 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 
 	r.GET(core.PathMe, gin.WrapH(mw(ac.GetMeHandler())))
 	r.POST(core.PathLogout, gin.WrapH(mw(ac.LogoutHandler())))
+	r.POST(core.PathChangePassword, gin.WrapH(mw(ac.ChangePasswordHandler())))
+	r.POST(core.PathChangeEmail, gin.WrapH(mw(ac.ChangeEmailHandler())))
 }

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -31,6 +31,9 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 		ac.VerifyEmailHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
 	}).Methods(http.MethodGet)
 	r.Handle(core.PathResendVerification, ac.ResendVerificationHandler()).Methods(http.MethodPost)
+	r.HandleFunc(core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.ConfirmEmailChangeHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
+	}).Methods(http.MethodGet)
 
 	if ac.CanLoginWithOAuth() {
 		r.HandleFunc(core.PathOAuthBegin, gothic.BeginAuthHandler).Methods(http.MethodGet)
@@ -51,4 +54,6 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 
 	r.Handle(core.PathMe, mw(ac.GetMeHandler())).Methods(http.MethodGet)
 	r.Handle(core.PathLogout, mw(ac.LogoutHandler())).Methods(http.MethodPost)
+	r.Handle(core.PathChangePassword, mw(ac.ChangePasswordHandler())).Methods(http.MethodPost)
+	r.Handle(core.PathChangeEmail, mw(ac.ChangeEmailHandler())).Methods(http.MethodPost)
 }

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -28,6 +28,9 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 		ac.VerifyEmailHandler(&StdHTTPParamExtractor{Req: r})(w, r)
 	})
 	mux.Handle("POST "+core.PathResendVerification, ac.ResendVerificationHandler())
+	mux.HandleFunc("GET "+core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.ConfirmEmailChangeHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		mux.HandleFunc("GET "+core.PathOAuthBegin, gothic.BeginAuthHandler)
@@ -48,4 +51,6 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 
 	mux.Handle("GET "+core.PathMe, mw(ac.GetMeHandler()))
 	mux.Handle("POST "+core.PathLogout, mw(ac.LogoutHandler()))
+	mux.Handle("POST "+core.PathChangePassword, mw(ac.ChangePasswordHandler()))
+	mux.Handle("POST "+core.PathChangeEmail, mw(ac.ChangeEmailHandler()))
 }

--- a/cmd/migrate/migrations/000001_init_schema.up.sql
+++ b/cmd/migrate/migrations/000001_init_schema.up.sql
@@ -43,7 +43,7 @@ CREATE TRIGGER sessions_set_updated_at
   BEFORE UPDATE ON sessions
   FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
-CREATE TYPE "verification_intent" AS ENUM ('password_reset', 'email_verification', 'magic_link');
+CREATE TYPE "verification_intent" AS ENUM ('password_reset', 'email_verification', 'magic_link', 'email_change');
 
 CREATE TABLE IF NOT EXISTS "verifications" (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/core/auth_client.go
+++ b/core/auth_client.go
@@ -32,6 +32,7 @@ type resolvedDurations struct {
 	emailVerification time.Duration
 	passwordReset     time.Duration
 	magicLink         time.Duration
+	emailChange       time.Duration
 }
 
 // Checks if mailer is configured and magic link redirect urls are also provided
@@ -107,6 +108,7 @@ func resolveDurations(s *SessionConfig, t *TokenConfig) resolvedDurations {
 		emailVerification: auth.DefaultTokenDuration,
 		passwordReset:     auth.DefaultTokenDuration,
 		magicLink:         auth.DefaultTokenDuration,
+		emailChange:       auth.DefaultTokenDuration,
 	}
 
 	if s != nil && s.Duration > 0 {
@@ -126,6 +128,9 @@ func resolveDurations(s *SessionConfig, t *TokenConfig) resolvedDurations {
 		}
 		if t.MagicLink > 0 {
 			d.magicLink = t.MagicLink
+		}
+		if t.EmailChange > 0 {
+			d.emailChange = t.EmailChange
 		}
 	}
 
@@ -199,6 +204,8 @@ func (ac *AuthClient) tokenExpiry(intent auth.VerificationIntent) time.Time {
 		d = ac.durations.passwordReset
 	case auth.MagicLinkIntent:
 		d = ac.durations.magicLink
+	case auth.EmailChangeIntent:
+		d = ac.durations.emailChange
 	default:
 		d = auth.DefaultTokenDuration
 	}

--- a/core/change_credentials_test.go
+++ b/core/change_credentials_test.go
@@ -1,0 +1,276 @@
+package core
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AdrianTworek/go-auth/core/internal/store"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+func loginCookie(t *testing.T, helper *TestHelper, userType TestUserType) *http.Cookie {
+	t.Helper()
+	_, rr := helper.LoginAs(userType)
+	cookie := helper.GetSessionCookie(rr)
+	require.NotNil(t, cookie, "expected a session cookie after login")
+	return cookie
+}
+
+// sessionCookieFor mints a valid session for a user directly, for accounts that can't
+// log in with a password (OAuth-only / magic-link-only).
+func sessionCookieFor(t *testing.T, app *TestApp, userID string) *http.Cookie {
+	t.Helper()
+	token, err := app.storage.Session.Create(t.Context(), nil, &store.Session{
+		UserID:    userID,
+		IPAddress: "",
+		UserAgent: "",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	return &http.Cookie{Name: "session", Value: token}
+}
+
+// insertPasswordlessUser creates a verified user with a NULL password and no OAuth
+// link — the shape of a magic-link-only account.
+func insertPasswordlessUser(t *testing.T, db *sql.DB, email string) string {
+	t.Helper()
+	var id string
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`INSERT INTO users (email, email_verified) VALUES ($1, true) RETURNING id`, email,
+	).Scan(&id))
+	return id
+}
+
+func userID(t *testing.T, db *sql.DB, email string) string {
+	t.Helper()
+	var id string
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT id FROM users WHERE email = $1`, email).Scan(&id))
+	return id
+}
+
+func doJSON(t *testing.T, app *TestApp, method, path string, cookie *http.Cookie, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	return rr
+}
+
+func doGet(t *testing.T, app *TestApp, path string, cookie *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	return rr
+}
+
+// mailToken returns the token argument from the first recorded call to the named
+// mailer method.
+func mailToken(t *testing.T, app *TestApp, method string) string {
+	t.Helper()
+	for _, c := range app.mailer.Calls {
+		if c.Method == method {
+			return c.Arguments[1].(string)
+		}
+	}
+	t.Fatalf("no %s mailer call was recorded", method)
+	return ""
+}
+
+// --- change password -------------------------------------------------------
+
+func Test_Integration_ChangePasswordSuccess(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	app.mailer.On("SendPasswordChangedEmail", TestUserData[DefaultUser].Email).Return(nil)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// A second, unrelated session for the same user, to prove it gets revoked.
+	otherCookie := sessionCookieFor(t, app, userID(t, db, TestUserData[DefaultUser].Email))
+
+	rr := doJSON(t, app, http.MethodPost, PathChangePassword, cookie, map[string]string{
+		"currentPassword": TestUserData[DefaultUser].Password,
+		"newPassword":     "NewP@ssword123!",
+		"confirmPassword": "NewP@ssword123!",
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+	app.mailer.AssertExpectations(t)
+
+	// The new password now works.
+	dbUser, err := app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
+	require.NoError(t, err)
+	assert.True(t, dbUser.Password.Compare("NewP@ssword123!"))
+
+	// The other device's session was revoked.
+	_, err = app.storage.Session.Validate(t.Context(), nil, otherCookie.Value)
+	assert.Error(t, err)
+
+	// A fresh session was issued for the current device.
+	newCookie := helper.GetSessionCookie(rr)
+	require.NotNil(t, newCookie)
+	_, err = app.storage.Session.Validate(t.Context(), nil, newCookie.Value)
+	assert.NoError(t, err)
+}
+
+func Test_Integration_ChangePasswordWrongCurrent(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangePassword, cookie, map[string]string{
+		"currentPassword": "not-my-password",
+		"newPassword":     "NewP@ssword123!",
+		"confirmPassword": "NewP@ssword123!",
+	})
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func Test_Integration_ChangePasswordNoPasswordUserDirectedToReset(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	uid := insertPasswordlessUser(t, db, "nopass@example.com")
+	cookie := sessionCookieFor(t, app, uid)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangePassword, cookie, map[string]string{
+		"currentPassword": "anything",
+		"newPassword":     "NewP@ssword123!",
+		"confirmPassword": "NewP@ssword123!",
+	})
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "password reset")
+}
+
+func Test_Integration_ChangePasswordRequiresAuth(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangePassword, nil, map[string]string{
+		"currentPassword": "x",
+		"newPassword":     "NewP@ssword123!",
+		"confirmPassword": "NewP@ssword123!",
+	})
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// --- change email ----------------------------------------------------------
+
+func Test_Integration_ChangeEmailFullFlow(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	newEmail := "changed@example.com"
+	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangeEmail, cookie, map[string]string{
+		"newEmail":        newEmail,
+		"currentPassword": TestUserData[DefaultUser].Password,
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+	app.mailer.AssertExpectations(t)
+
+	// The email is NOT changed until the link is visited.
+	_, err := app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
+	require.NoError(t, err)
+
+	// Visit the confirmation link.
+	token := mailToken(t, app, "SendEmailChangeEmail")
+	confirmRR := doGet(t, app, strings.Replace(PathConfirmEmailChange, "{token}", token, 1), nil)
+	require.Equal(t, http.StatusOK, confirmRR.Code)
+
+	// The account now uses the new (verified) email, and the old one no longer resolves.
+	changed, err := app.storage.User.GetByEmail(t.Context(), nil, newEmail)
+	require.NoError(t, err)
+	assert.True(t, changed.EmailVerified)
+	_, err = app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func Test_Integration_ChangeEmailOAuthLinkedBlocked(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// Link an OAuth provider to the account.
+	_, err := db.ExecContext(t.Context(),
+		`UPDATE users SET oauth_provider = 'google', oauth_id = 'oauth-123' WHERE email = $1`,
+		TestUserData[DefaultUser].Email)
+	require.NoError(t, err)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangeEmail, cookie, map[string]string{
+		"newEmail":        "brand-new@example.com",
+		"currentPassword": TestUserData[DefaultUser].Password,
+	})
+	assert.Equal(t, http.StatusConflict, rr.Code)
+	assert.Contains(t, rr.Body.String(), "google")
+}
+
+func Test_Integration_ChangeEmailAlreadyTaken(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangeEmail, cookie, map[string]string{
+		"newEmail":        TestUserData[UnverifiedUser].Email, // already registered
+		"currentPassword": TestUserData[DefaultUser].Password,
+	})
+	assert.Equal(t, http.StatusConflict, rr.Code)
+}
+
+func Test_Integration_ChangeEmailNoPasswordUserSkipsReauth(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	newEmail := "ml-new@example.com"
+	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
+
+	uid := insertPasswordlessUser(t, db, "magiclink@example.com")
+	cookie := sessionCookieFor(t, app, uid)
+
+	// No currentPassword supplied; the session plus new-email verification is the control.
+	rr := doJSON(t, app, http.MethodPost, PathChangeEmail, cookie, map[string]string{
+		"newEmail": newEmail,
+	})
+	assert.Equal(t, http.StatusOK, rr.Code)
+	app.mailer.AssertExpectations(t)
+}
+
+func Test_Integration_ConfirmEmailChangeInvalidToken(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doGet(t, app, strings.Replace(PathConfirmEmailChange, "{token}", "not-a-real-token", 1), nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}

--- a/core/config.go
+++ b/core/config.go
@@ -121,4 +121,9 @@ type TokenConfig struct {
 	//
 	// Default: 5 minutes
 	MagicLink time.Duration
+	// EmailChange is the lifetime of the confirmation link sent to a new email
+	// address when an authenticated user changes their email.
+	//
+	// Default: 5 minutes
+	EmailChange time.Duration
 }

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -894,6 +895,262 @@ func (ac *AuthClient) CompletePasswordResetHandler(extractor ParamExtractor) htt
 		}
 
 		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Password reset successfully"})
+	}
+}
+
+// ChangePasswordHandler lets an authenticated user change their password. It must be
+// mounted behind AuthMiddleware. The current password is required as re-authentication
+// so a hijacked session alone can't rotate the password. On success every other
+// session is revoked (the current device is re-issued a fresh session) and the account
+// is notified by email.
+func (ac *AuthClient) ChangePasswordHandler() http.HandlerFunc {
+	type request struct {
+		CurrentPassword string `json:"currentPassword" validate:"required"`
+		NewPassword     string `json:"newPassword" validate:"required,min=8,max=72"`
+		ConfirmPassword string `json:"confirmPassword" validate:"required,min=8,max=72,eqfield=NewPassword"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := getUserFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+
+		var req request
+		if err := readAndValidateJSON(w, r, &req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		// OAuth-only and magic-link-only accounts have no password to change. Direct
+		// them to the password-reset flow, which can set a first password.
+		if len(user.Password) == 0 {
+			writeJSONError(w, http.StatusBadRequest, "No password is set for this account. Use the password reset flow to set one.")
+			return
+		}
+
+		if !user.Password.Compare(req.CurrentPassword) {
+			writeJSONError(w, http.StatusBadRequest, "Current password is incorrect")
+			return
+		}
+
+		if req.NewPassword == req.CurrentPassword {
+			writeJSONError(w, http.StatusBadRequest, "New password must be different from the current password")
+			return
+		}
+
+		tx, err := ac.store.Transaction.Begin()
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+		defer func(tx *sqlx.Tx) {
+			if err != nil {
+				if rbErr := ac.store.Transaction.Rollback(tx); rbErr != nil {
+					slog.Error("rollback error", "error", rbErr)
+				}
+			}
+		}(tx)
+
+		if err = user.Password.Set(req.NewPassword); err != nil {
+			serverError(w, r, err)
+			return
+		}
+		if _, err = ac.store.User.Update(r.Context(), tx, user); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		// Revoke every session (logs out other devices), then issue a fresh one for the
+		// current device so this request stays authenticated.
+		if err = ac.store.Session.DeleteForUser(r.Context(), tx, user.ID); err != nil {
+			serverError(w, r, err)
+			return
+		}
+		expiresAt := ac.sessionExpiry()
+		newToken, err := ac.store.Session.Create(r.Context(), tx, &store.Session{
+			UserID:    user.ID,
+			IPAddress: r.RemoteAddr,
+			UserAgent: r.UserAgent(),
+			ExpiresAt: expiresAt,
+		})
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.store.Transaction.Commit(tx); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		http.SetCookie(w, ac.newSessionCookie(newToken, expiresAt))
+
+		// Best-effort notification; a failure here must not fail the request.
+		if mailErr := ac.config.Mailer.SendPasswordChangedEmail(user.Email); mailErr != nil {
+			slog.Error("failed to send password changed email", "error", mailErr)
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Password changed successfully"})
+	}
+}
+
+// ChangeEmailHandler lets an authenticated user request an email change. It must be
+// mounted behind AuthMiddleware. The change is not applied here: a confirmation link is
+// sent to the NEW address and the change only takes effect when ConfirmEmailChangeHandler
+// consumes that token, so the account email is never set to an unverified address.
+//
+// OAuth-linked accounts are rejected: OAuthCallbackHandler matches returning users by
+// email, so changing it would orphan the account on the next OAuth sign-in. Password
+// accounts must re-authenticate with their current password; magic-link-only accounts
+// have no password, so their session plus the new-email verification is the control.
+func (ac *AuthClient) ChangeEmailHandler() http.HandlerFunc {
+	type request struct {
+		NewEmail        string `json:"newEmail" validate:"required,email,max=255"`
+		CurrentPassword string `json:"currentPassword" validate:"omitempty,max=72"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := getUserFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+
+		var req request
+		if err := readAndValidateJSON(w, r, &req); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if user.OAuthProvider != nil && user.OAuthProvider.Valid {
+			writeJSONError(w, http.StatusConflict, "Your email is managed by your linked "+user.OAuthProvider.String+" account and can't be changed here.")
+			return
+		}
+
+		// Re-authenticate accounts that have a password. Magic-link-only accounts have
+		// none; for them the session and the new-email verification are the control.
+		if len(user.Password) > 0 && !user.Password.Compare(req.CurrentPassword) {
+			writeJSONError(w, http.StatusBadRequest, "Current password is incorrect")
+			return
+		}
+
+		if strings.EqualFold(req.NewEmail, user.Email) {
+			writeJSONError(w, http.StatusBadRequest, "The new email is the same as your current email")
+			return
+		}
+
+		// Reject an address already registered to another account.
+		if _, err := ac.store.User.GetByEmail(r.Context(), nil, req.NewEmail); err == nil {
+			writeJSONError(w, http.StatusConflict, "That email address is already in use")
+			return
+		} else if !errors.Is(err, store.ErrNotFound) {
+			serverError(w, r, err)
+			return
+		}
+
+		tx, err := ac.store.Transaction.Begin()
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+		defer func(tx *sqlx.Tx) {
+			if err != nil {
+				if rbErr := ac.store.Transaction.Rollback(tx); rbErr != nil {
+					slog.Error("rollback error", "error", rbErr)
+				}
+			}
+		}(tx)
+
+		// The token carries the pending new email; the user_id ties it to this account.
+		verificationToken, err := ac.store.Verification.Create(
+			r.Context(),
+			tx,
+			ac.newVerification(
+				auth.EmailChangeIntent,
+				auth.NewNullString(req.NewEmail),
+				auth.NewNullString(user.ID),
+			),
+		)
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.config.Mailer.SendEmailChangeEmail(req.NewEmail, verificationToken); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.store.Transaction.Commit(tx); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "A confirmation link has been sent to your new email address."})
+	}
+}
+
+// ConfirmEmailChangeHandler applies an email change once the user visits the link sent
+// to their new address. It is a public endpoint authorized solely by the single-use
+// token, so it must not be mounted behind AuthMiddleware.
+func (ac *AuthClient) ConfirmEmailChangeHandler(extractor ParamExtractor) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokenStr := extractor.GetParam("token")
+		if tokenStr == "" {
+			writeJSONError(w, http.StatusBadRequest, "Token is required")
+			return
+		}
+
+		tx, err := ac.store.Transaction.Begin()
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+		defer func(tx *sqlx.Tx) {
+			if err != nil {
+				if rbErr := ac.store.Transaction.Rollback(tx); rbErr != nil {
+					slog.Error("rollback error", "error", rbErr)
+				}
+			}
+		}(tx)
+
+		// Atomically validate and consume the token; a rollback below restores it.
+		token, err := ac.store.Verification.Consume(r.Context(), tx, tokenStr, auth.EmailChangeIntent)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "Invalid token")
+			return
+		}
+		if !token.UserID.Valid || !token.Email.Valid {
+			writeJSONError(w, http.StatusBadRequest, "Invalid token")
+			return
+		}
+
+		user, err := ac.store.User.GetByID(r.Context(), tx, token.UserID.String)
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		user.Email = token.Email.String
+		user.EmailVerified = true
+		if _, err = ac.store.User.Update(r.Context(), tx, user); err != nil {
+			// The address may have been taken between request and confirmation.
+			if errors.Is(err, store.ErrDuplicateEmail) {
+				writeJSONError(w, http.StatusConflict, "That email address is already in use")
+				return
+			}
+			serverError(w, r, err)
+			return
+		}
+
+		if err = ac.store.Transaction.Commit(tx); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Email changed successfully"})
 	}
 }
 

--- a/core/internal/auth/auth.go
+++ b/core/internal/auth/auth.go
@@ -35,18 +35,21 @@ const (
 	PasswordResetIntent VerificationIntent = iota
 	EmailVerificationIntent
 	MagicLinkIntent
+	EmailChangeIntent
 )
 
 var verificationIntentToString = map[VerificationIntent]string{
 	PasswordResetIntent:     "password_reset",
 	EmailVerificationIntent: "email_verification",
 	MagicLinkIntent:         "magic_link",
+	EmailChangeIntent:       "email_change",
 }
 
 var stringToVerificationIntent = map[string]VerificationIntent{
 	"password_reset":     PasswordResetIntent,
 	"email_verification": EmailVerificationIntent,
 	"magic_link":         MagicLinkIntent,
+	"email_change":       EmailChangeIntent,
 }
 
 func (v VerificationIntent) String() string {

--- a/core/internal/store/user.go
+++ b/core/internal/store/user.go
@@ -13,6 +13,17 @@ import (
 
 var ErrDuplicateEmail = errors.New("duplicate email")
 
+// mapDuplicateEmail converts a Postgres unique-violation (23505) into
+// ErrDuplicateEmail. users has a single unique constraint (email), so any unique
+// violation maps to a duplicate email.
+func mapDuplicateEmail(err error) error {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+		return ErrDuplicateEmail
+	}
+	return err
+}
+
 type User struct {
 	BaseEntity
 	Email         string           `json:"email" db:"email"`
@@ -69,13 +80,7 @@ func (s *UserStore) Create(ctx context.Context, tx *sqlx.Tx, user *User) error {
 	}
 
 	if err != nil {
-		// 23505 = unique_violation; users has a single unique constraint (email),
-		// so any unique violation on insert is a duplicate email.
-		var pqErr *pq.Error
-		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
-			return ErrDuplicateEmail
-		}
-		return err
+		return mapDuplicateEmail(err)
 	}
 
 	return nil
@@ -164,11 +169,11 @@ func (s *UserStore) Update(ctx context.Context, tx *sqlx.Tx, user *User) (*User,
 		}
 		rows, err = query.QueryxContext(ctx, user)
 		if err != nil {
-			return nil, err
+			return nil, mapDuplicateEmail(err)
 		}
 	}
 	if err != nil {
-		return nil, err
+		return nil, mapDuplicateEmail(err)
 	}
 
 	updated := &User{}

--- a/core/mailer/mailer.go
+++ b/core/mailer/mailer.go
@@ -7,6 +7,7 @@ type Mailer interface {
 	SendPasswordResetEmail(to, token string) error
 	SendPasswordChangedEmail(to string) error
 	SendMagicLinkEmail(to, token string) error
+	SendEmailChangeEmail(to, token string) error
 }
 
 type AppMailer struct {
@@ -36,6 +37,14 @@ func (m *AppMailer) SendMagicLinkEmail(to, token string) error {
 	// Send an email to the user with the magic link token
 	magicLinkURL := fmt.Sprintf("%s/auth/magic-link/%s", m.baseURL, token)
 	fmt.Printf("Sending magic link mail to %s from %s url: %s\n", to, m.from, magicLinkURL)
+	return nil
+}
+
+func (m *AppMailer) SendEmailChangeEmail(to, token string) error {
+	// Send a confirmation link to the user's NEW email address; the change applies
+	// only when this link is visited.
+	changeURL := fmt.Sprintf("%s/auth/change-email/%s", m.baseURL, token)
+	fmt.Printf("Sending email-change confirmation to %s from %s url: %s\n", to, m.from, changeURL)
 	return nil
 }
 

--- a/core/routes.go
+++ b/core/routes.go
@@ -21,6 +21,9 @@ const (
 	PathMagicLink          = "/auth/magic-link/{token}"
 	PathSendPasswordReset  = "/auth/reset-password"         // #nosec G101 -- URL path, not a credential
 	PathPasswordReset      = "/auth/reset-password/{token}" // #nosec G101 -- URL path, not a credential
+	PathChangePassword     = "/auth/change-password"        // #nosec G101 -- URL path, not a credential
+	PathChangeEmail        = "/auth/change-email"
+	PathConfirmEmailChange = "/auth/change-email/{token}"
 )
 
 // ColonParamPattern converts a canonical "{name}" path pattern to the ":name" form

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -50,6 +50,11 @@ func (m *MockMailer) SendMagicLinkEmail(to, token string) error {
 	return args.Error(0)
 }
 
+func (m *MockMailer) SendEmailChangeEmail(to, token string) error {
+	args := m.Called(to, token)
+	return args.Error(0)
+}
+
 type ChiParamExtractor struct {
 	Req *http.Request
 }
@@ -126,9 +131,14 @@ func (a *TestApp) Router() *chi.Mux {
 	r.Put(PathPasswordReset, func(w http.ResponseWriter, r *http.Request) {
 		ac.CompletePasswordResetHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
+	r.Get(PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.ConfirmEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
+	})
 
 	r.With(mw).Get(PathMe, ac.GetMeHandler())
 	r.With(mw).Post(PathLogout, ac.LogoutHandler())
+	r.With(mw).Post(PathChangePassword, ac.ChangePasswordHandler())
+	r.With(mw).Post(PathChangeEmail, ac.ChangeEmailHandler())
 
 	return r
 }


### PR DESCRIPTION
Two authenticated account-management endpoints (behind `AuthMiddleware`), with the OAuth edges handled deliberately.

## `POST /auth/change-password`
Requires `currentPassword` (re-auth, so a hijacked session alone can't rotate it). On success: re-hash, **revoke every other session** (the current device gets a fresh session cookie), and send `SendPasswordChangedEmail`.

- **OAuth-only / magic-link-only accounts** have no password — rejected with a message pointing to the password-reset flow (which *can* set a first password). Detected by `len(user.Password) == 0` (a NULL password column).

## `POST /auth/change-email` + `GET /auth/change-email/{token}`
**Two-step verified change.** The request sends a confirmation link to the **new** address; the change is applied (and marked verified) only when that link is visited — so the account email is never briefly set to an unverified/unowned address.

| Case | Behaviour |
|---|---|
| OAuth-linked account | **Blocked (409)** — `OAuthCallbackHandler` matches returning users *by email*, so changing it would orphan the account (a duplicate is created on next OAuth sign-in). Proper support is the Phase 2 accounts-table rework. |
| Password account | Re-authenticates with `currentPassword`. |
| Magic-link-only account (no password) | `currentPassword` skipped — the session + new-email verification is the control. |
| New address already registered | 409 (also caught at confirm time via a unique-violation → `ErrDuplicateEmail`, in case it's taken between request and confirm). |

## Supporting changes
- `email_change` verification intent — **folded into `000001_init_schema`** per your call (no external users). ⚠️ **Existing local dev DBs won't pick this up** (migrate won't re-run an applied migration) — recreate your dev DB. Test containers are fresh, so CI is unaffected.
- `Mailer.SendEmailChangeEmail(to, token)` added to the interface (default `AppMailer` implements it). Not flagged as a breaking change, per your guidance.
- `Tokens.EmailChange` configurable lifetime (default 5m), consistent with the other per-intent token durations.
- `UserStore.Update` now maps a Postgres unique violation to `ErrDuplicateEmail` (shared with `Create` via a helper).
- All six adapters wired; the conformance test now covers 15 routes × 6 adapters.

## Tests
9 integration tests in `core/change_credentials_test.go`: change-password success (new password works, other sessions revoked, current re-issued) / wrong current / no-password→reset / requires-auth; change-email full request→confirm flow / OAuth-linked blocked / already-taken / no-password skips re-auth / invalid confirm token.

Full suite green; conformance green; `go vet` / `gofmt` / `golangci-lint` all clean.

## Follow-up (not here)
- Notify the **old** address on email change (extra safety against a typo'd/hostile new address) — needs another mailer method.
- Audit hooks for these events (kept out to stay focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
