### PR TITLE
feat(core): harden email change — old-address notification, cancel link, completion notice

### DIFF
--- a/adapters/chi/chi_adapter.go
+++ b/adapters/chi/chi_adapter.go
@@ -34,6 +34,9 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 	r.Get(core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
 		ac.ConfirmEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
+	r.Get(core.PathCancelEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.CancelEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		r.Get(core.PathOAuthBegin, gothic.BeginAuthHandler)

--- a/adapters/conformance/conformance_test.go
+++ b/adapters/conformance/conformance_test.go
@@ -116,6 +116,7 @@ func Test_Conformance_AdaptersRegisterAllRoutes(t *testing.T) {
 		{http.MethodPost, core.PathSendPasswordReset},
 		{http.MethodPut, withToken(core.PathPasswordReset)},
 		{http.MethodGet, withToken(core.PathConfirmEmailChange)},
+		{http.MethodGet, withToken(core.PathCancelEmailChange)},
 		{http.MethodGet, core.PathMe},
 		{http.MethodPost, core.PathLogout},
 		{http.MethodPost, core.PathChangePassword},

--- a/adapters/echo/echo_adapter.go
+++ b/adapters/echo/echo_adapter.go
@@ -32,6 +32,9 @@ func InitAuth(ac *core.AuthClient, e *echo.Echo) {
 	e.GET(core.ColonParamPattern(core.PathConfirmEmailChange), func(c echo.Context) error {
 		return echo.WrapHandler(ac.ConfirmEmailChangeHandler(&EchoParamExtractor{Ctx: c}))(c)
 	})
+	e.GET(core.ColonParamPattern(core.PathCancelEmailChange), func(c echo.Context) error {
+		return echo.WrapHandler(ac.CancelEmailChangeHandler(&EchoParamExtractor{Ctx: c}))(c)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		e.GET(core.PathOAuthBegin, func(c echo.Context) error {

--- a/adapters/fiber/fiber_adapter.go
+++ b/adapters/fiber/fiber_adapter.go
@@ -33,6 +33,9 @@ func InitAuth(ac *core.AuthClient, app *fiber.App) {
 	app.Get(core.ColonParamPattern(core.PathConfirmEmailChange), func(c *fiber.Ctx) error {
 		return adaptor.HTTPHandlerFunc(ac.ConfirmEmailChangeHandler(&FiberParamExtractor{Ctx: c}))(c)
 	})
+	app.Get(core.ColonParamPattern(core.PathCancelEmailChange), func(c *fiber.Ctx) error {
+		return adaptor.HTTPHandlerFunc(ac.CancelEmailChangeHandler(&FiberParamExtractor{Ctx: c}))(c)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		app.Get(core.PathOAuthBegin, adaptor.HTTPHandlerFunc(gothic.BeginAuthHandler))

--- a/adapters/gin/gin_adapter.go
+++ b/adapters/gin/gin_adapter.go
@@ -32,6 +32,9 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 	r.GET(core.ColonParamPattern(core.PathConfirmEmailChange), func(c *gin.Context) {
 		ac.ConfirmEmailChangeHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
 	})
+	r.GET(core.ColonParamPattern(core.PathCancelEmailChange), func(c *gin.Context) {
+		ac.CancelEmailChangeHandler(&GinParamExtractor{Ctx: c})(c.Writer, c.Request)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		r.GET(core.PathOAuthBegin, gin.WrapF(gothic.BeginAuthHandler))

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -34,6 +34,9 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 	r.HandleFunc(core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
 		ac.ConfirmEmailChangeHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
 	}).Methods(http.MethodGet)
+	r.HandleFunc(core.PathCancelEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.CancelEmailChangeHandler(&GorillaParamExtractor{Vars: mux.Vars(r)}).ServeHTTP(w, r)
+	}).Methods(http.MethodGet)
 
 	if ac.CanLoginWithOAuth() {
 		r.HandleFunc(core.PathOAuthBegin, gothic.BeginAuthHandler).Methods(http.MethodGet)

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -31,6 +31,9 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 	mux.HandleFunc("GET "+core.PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
 		ac.ConfirmEmailChangeHandler(&StdHTTPParamExtractor{Req: r})(w, r)
 	})
+	mux.HandleFunc("GET "+core.PathCancelEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.CancelEmailChangeHandler(&StdHTTPParamExtractor{Req: r})(w, r)
+	})
 
 	if ac.CanLoginWithOAuth() {
 		mux.HandleFunc("GET "+core.PathOAuthBegin, gothic.BeginAuthHandler)

--- a/core/change_credentials_test.go
+++ b/core/change_credentials_test.go
@@ -186,6 +186,8 @@ func Test_Integration_ChangeEmailFullFlow(t *testing.T) {
 
 	newEmail := "changed@example.com"
 	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
+	// The current (old) address is alerted that a change was requested.
+	app.mailer.On("SendEmailChangeNotification", TestUserData[DefaultUser].Email, newEmail).Return(nil)
 
 	helper := newTestHelper(t, app)
 	cookie := loginCookie(t, helper, DefaultUser)
@@ -254,9 +256,11 @@ func Test_Integration_ChangeEmailNoPasswordUserSkipsReauth(t *testing.T) {
 	defer CleanupIntegration(t, dbCtr, db)
 
 	newEmail := "ml-new@example.com"
+	oldEmail := "magiclink@example.com"
 	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
+	app.mailer.On("SendEmailChangeNotification", oldEmail, newEmail).Return(nil)
 
-	uid := insertPasswordlessUser(t, db, "magiclink@example.com")
+	uid := insertPasswordlessUser(t, db, oldEmail)
 	cookie := sessionCookieFor(t, app, uid)
 
 	// No currentPassword supplied; the session plus new-email verification is the control.

--- a/core/change_credentials_test.go
+++ b/core/change_credentials_test.go
@@ -186,8 +186,10 @@ func Test_Integration_ChangeEmailFullFlow(t *testing.T) {
 
 	newEmail := "changed@example.com"
 	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
-	// The current (old) address is alerted that a change was requested.
-	app.mailer.On("SendEmailChangeNotification", TestUserData[DefaultUser].Email, newEmail).Return(nil)
+	// The current (old) address is alerted that a change was requested (with a cancel
+	// link), and alerted again once the change completes.
+	app.mailer.On("SendEmailChangeNotification", TestUserData[DefaultUser].Email, newEmail, mock.Anything).Return(nil)
+	app.mailer.On("SendEmailChangeCompletedNotification", TestUserData[DefaultUser].Email, newEmail).Return(nil)
 
 	helper := newTestHelper(t, app)
 	cookie := loginCookie(t, helper, DefaultUser)
@@ -197,7 +199,6 @@ func Test_Integration_ChangeEmailFullFlow(t *testing.T) {
 		"currentPassword": TestUserData[DefaultUser].Password,
 	})
 	require.Equal(t, http.StatusOK, rr.Code)
-	app.mailer.AssertExpectations(t)
 
 	// The email is NOT changed until the link is visited.
 	_, err := app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
@@ -214,6 +215,10 @@ func Test_Integration_ChangeEmailFullFlow(t *testing.T) {
 	assert.True(t, changed.EmailVerified)
 	_, err = app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
 	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// All three mails fired: confirmation to the new address, plus the request-time and
+	// completion notifications to the old address.
+	app.mailer.AssertExpectations(t)
 }
 
 func Test_Integration_ChangeEmailOAuthLinkedBlocked(t *testing.T) {
@@ -258,7 +263,7 @@ func Test_Integration_ChangeEmailNoPasswordUserSkipsReauth(t *testing.T) {
 	newEmail := "ml-new@example.com"
 	oldEmail := "magiclink@example.com"
 	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
-	app.mailer.On("SendEmailChangeNotification", oldEmail, newEmail).Return(nil)
+	app.mailer.On("SendEmailChangeNotification", oldEmail, newEmail, mock.Anything).Return(nil)
 
 	uid := insertPasswordlessUser(t, db, oldEmail)
 	cookie := sessionCookieFor(t, app, uid)
@@ -276,5 +281,48 @@ func Test_Integration_ConfirmEmailChangeInvalidToken(t *testing.T) {
 	defer CleanupIntegration(t, dbCtr, db)
 
 	rr := doGet(t, app, strings.Replace(PathConfirmEmailChange, "{token}", "not-a-real-token", 1), nil)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// Test_Integration_CancelEmailChange verifies the cancel link (sent to the old address)
+// aborts a pending change: the token is consumed, so confirmation no longer works and
+// the account email is left untouched.
+func Test_Integration_CancelEmailChange(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	newEmail := "canceled@example.com"
+	app.mailer.On("SendEmailChangeEmail", newEmail, mock.Anything).Return(nil)
+	app.mailer.On("SendEmailChangeNotification", TestUserData[DefaultUser].Email, newEmail, mock.Anything).Return(nil)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	rr := doJSON(t, app, http.MethodPost, PathChangeEmail, cookie, map[string]string{
+		"newEmail":        newEmail,
+		"currentPassword": TestUserData[DefaultUser].Password,
+	})
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The confirm and cancel links carry the same single-use token.
+	token := mailToken(t, app, "SendEmailChangeEmail")
+	cancelRR := doGet(t, app, strings.Replace(PathCancelEmailChange, "{token}", token, 1), nil)
+	require.Equal(t, http.StatusOK, cancelRR.Code)
+
+	// Confirmation now fails (token consumed), and the email is untouched.
+	confirmRR := doGet(t, app, strings.Replace(PathConfirmEmailChange, "{token}", token, 1), nil)
+	assert.Equal(t, http.StatusBadRequest, confirmRR.Code)
+
+	_, err := app.storage.User.GetByEmail(t.Context(), nil, TestUserData[DefaultUser].Email)
+	assert.NoError(t, err)
+	_, err = app.storage.User.GetByEmail(t.Context(), nil, newEmail)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func Test_Integration_CancelEmailChangeInvalidToken(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doGet(t, app, strings.Replace(PathCancelEmailChange, "{token}", "not-a-real-token", 1), nil)
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -1088,6 +1088,14 @@ func (ac *AuthClient) ChangeEmailHandler() http.HandlerFunc {
 			return
 		}
 
+		// Alert the current (old) address that a change was requested, so the account
+		// owner can react while it is still pending — the change only applies once the
+		// link sent to the new address is visited. Best-effort; user.Email is still the
+		// old address here.
+		if mailErr := ac.config.Mailer.SendEmailChangeNotification(user.Email, req.NewEmail); mailErr != nil {
+			slog.Error("failed to send email-change notification", "error", mailErr)
+		}
+
 		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "A confirmation link has been sent to your new email address."})
 	}
 }

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -1092,7 +1092,7 @@ func (ac *AuthClient) ChangeEmailHandler() http.HandlerFunc {
 		// owner can react while it is still pending — the change only applies once the
 		// link sent to the new address is visited. Best-effort; user.Email is still the
 		// old address here.
-		if mailErr := ac.config.Mailer.SendEmailChangeNotification(user.Email, req.NewEmail); mailErr != nil {
+		if mailErr := ac.config.Mailer.SendEmailChangeNotification(user.Email, req.NewEmail, verificationToken); mailErr != nil {
 			slog.Error("failed to send email-change notification", "error", mailErr)
 		}
 
@@ -1141,7 +1141,11 @@ func (ac *AuthClient) ConfirmEmailChangeHandler(extractor ParamExtractor) http.H
 			return
 		}
 
-		user.Email = token.Email.String
+		// Capture the previous address before overwriting it, so it can be notified.
+		oldEmail := user.Email
+		newEmail := token.Email.String
+
+		user.Email = newEmail
 		user.EmailVerified = true
 		if _, err = ac.store.User.Update(r.Context(), tx, user); err != nil {
 			// The address may have been taken between request and confirmation.
@@ -1158,7 +1162,35 @@ func (ac *AuthClient) ConfirmEmailChangeHandler(extractor ParamExtractor) http.H
 			return
 		}
 
+		// Alert the previous address that the change completed (best-effort).
+		if mailErr := ac.config.Mailer.SendEmailChangeCompletedNotification(oldEmail, newEmail); mailErr != nil {
+			slog.Error("failed to send email-change completed notification", "error", mailErr)
+		}
+
 		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Email changed successfully"})
+	}
+}
+
+// CancelEmailChangeHandler aborts a pending email change from the link included in the
+// notification sent to the current (old) address. It consumes the change token without
+// applying it, so the request can no longer be confirmed. Like the confirm endpoint it
+// is public, authorized solely by the single-use token, so it must not be mounted
+// behind AuthMiddleware.
+func (ac *AuthClient) CancelEmailChangeHandler(extractor ParamExtractor) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokenStr := extractor.GetParam("token")
+		if tokenStr == "" {
+			writeJSONError(w, http.StatusBadRequest, "Token is required")
+			return
+		}
+
+		// Consume (delete) the token without applying the change.
+		if _, err := ac.store.Verification.Consume(r.Context(), nil, tokenStr, auth.EmailChangeIntent); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "Invalid or expired token")
+			return
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "The pending email change has been cancelled."})
 	}
 }
 

--- a/core/mailer/mailer.go
+++ b/core/mailer/mailer.go
@@ -8,6 +8,9 @@ type Mailer interface {
 	SendPasswordChangedEmail(to string) error
 	SendMagicLinkEmail(to, token string) error
 	SendEmailChangeEmail(to, token string) error
+	// SendEmailChangeNotification alerts a user's current (old) address that a change
+	// to newEmail was requested, so the owner can react while it is still pending.
+	SendEmailChangeNotification(to, newEmail string) error
 }
 
 type AppMailer struct {
@@ -45,6 +48,12 @@ func (m *AppMailer) SendEmailChangeEmail(to, token string) error {
 	// only when this link is visited.
 	changeURL := fmt.Sprintf("%s/auth/change-email/%s", m.baseURL, token)
 	fmt.Printf("Sending email-change confirmation to %s from %s url: %s\n", to, m.from, changeURL)
+	return nil
+}
+
+func (m *AppMailer) SendEmailChangeNotification(to, newEmail string) error {
+	// Alert the user's current (old) address that a change to newEmail was requested.
+	fmt.Printf("Notifying %s from %s that an email change to %s was requested\n", to, m.from, newEmail)
 	return nil
 }
 

--- a/core/mailer/mailer.go
+++ b/core/mailer/mailer.go
@@ -10,7 +10,11 @@ type Mailer interface {
 	SendEmailChangeEmail(to, token string) error
 	// SendEmailChangeNotification alerts a user's current (old) address that a change
 	// to newEmail was requested, so the owner can react while it is still pending.
-	SendEmailChangeNotification(to, newEmail string) error
+	// cancelToken lets the message include a link that aborts the pending change.
+	SendEmailChangeNotification(to, newEmail, cancelToken string) error
+	// SendEmailChangeCompletedNotification alerts a user's previous (old) address that
+	// their account email was changed to newEmail.
+	SendEmailChangeCompletedNotification(to, newEmail string) error
 }
 
 type AppMailer struct {
@@ -51,9 +55,17 @@ func (m *AppMailer) SendEmailChangeEmail(to, token string) error {
 	return nil
 }
 
-func (m *AppMailer) SendEmailChangeNotification(to, newEmail string) error {
-	// Alert the user's current (old) address that a change to newEmail was requested.
-	fmt.Printf("Notifying %s from %s that an email change to %s was requested\n", to, m.from, newEmail)
+func (m *AppMailer) SendEmailChangeNotification(to, newEmail, cancelToken string) error {
+	// Alert the user's current (old) address that a change to newEmail was requested,
+	// with a link to cancel it while it is still pending.
+	cancelURL := fmt.Sprintf("%s/auth/change-email/%s/cancel", m.baseURL, cancelToken)
+	fmt.Printf("Notifying %s from %s that an email change to %s was requested; cancel: %s\n", to, m.from, newEmail, cancelURL)
+	return nil
+}
+
+func (m *AppMailer) SendEmailChangeCompletedNotification(to, newEmail string) error {
+	// Alert the user's previous (old) address that the account email was changed.
+	fmt.Printf("Notifying %s from %s that the account email was changed to %s\n", to, m.from, newEmail)
 	return nil
 }
 

--- a/core/routes.go
+++ b/core/routes.go
@@ -24,6 +24,7 @@ const (
 	PathChangePassword     = "/auth/change-password"        // #nosec G101 -- URL path, not a credential
 	PathChangeEmail        = "/auth/change-email"
 	PathConfirmEmailChange = "/auth/change-email/{token}"
+	PathCancelEmailChange  = "/auth/change-email/{token}/cancel"
 )
 
 // ColonParamPattern converts a canonical "{name}" path pattern to the ":name" form

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -55,7 +55,12 @@ func (m *MockMailer) SendEmailChangeEmail(to, token string) error {
 	return args.Error(0)
 }
 
-func (m *MockMailer) SendEmailChangeNotification(to, newEmail string) error {
+func (m *MockMailer) SendEmailChangeNotification(to, newEmail, cancelToken string) error {
+	args := m.Called(to, newEmail, cancelToken)
+	return args.Error(0)
+}
+
+func (m *MockMailer) SendEmailChangeCompletedNotification(to, newEmail string) error {
 	args := m.Called(to, newEmail)
 	return args.Error(0)
 }
@@ -138,6 +143,9 @@ func (a *TestApp) Router() *chi.Mux {
 	})
 	r.Get(PathConfirmEmailChange, func(w http.ResponseWriter, r *http.Request) {
 		ac.ConfirmEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
+	})
+	r.Get(PathCancelEmailChange, func(w http.ResponseWriter, r *http.Request) {
+		ac.CancelEmailChangeHandler(&ChiParamExtractor{Req: r})(w, r)
 	})
 
 	r.With(mw).Get(PathMe, ac.GetMeHandler())

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -55,6 +55,11 @@ func (m *MockMailer) SendEmailChangeEmail(to, token string) error {
 	return args.Error(0)
 }
 
+func (m *MockMailer) SendEmailChangeNotification(to, newEmail string) error {
+	args := m.Called(to, newEmail)
+	return args.Error(0)
+}
+
 type ChiParamExtractor struct {
 	Req *http.Request
 }


### PR DESCRIPTION
Hardens the change-email flow (#48) around the typo'd-or-hostile new-address case: the confirmation link goes to the **new** address, which the account owner may not control.

## What
1. **Request-time notification to the old address** — when a change is requested, alert the current address that a change to X was requested (best-effort).
2. **Cancel link** — that notification includes `GET /auth/change-email/{token}/cancel`, letting the owner abort a pending change before it's confirmed. Same single-use token as confirm; whichever is visited first wins.
3. **Completion notice** — on confirmation, notify the previous address that the change completed (best-effort).

## Details
- `Mailer` gains `SendEmailChangeNotification(to, newEmail, cancelToken)` (now carries the cancel token) and `SendEmailChangeCompletedNotification(to, newEmail)`; the default `AppMailer` logs them.
- The cancel route sits at `/auth/change-email/{token}/cancel` (a child of the confirm param segment) specifically to avoid a static-vs-param route conflict with `/auth/change-email/{token}` — httprouter-based routers (gin) would panic otherwise.
- `CancelEmailChangeHandler` consumes the change token without applying it — public, authorized solely by the single-use token, not behind auth middleware.

## Tests
- The full request → confirm flow now asserts all three mails; new `Test_Integration_CancelEmailChange` (cancel consumes the token → confirm then fails, email untouched) + an invalid-token cancel.
- All six adapters wired; conformance covers the new route. Full suite + `go vet` / `gofmt` / `golangci-lint` green.

## Commits
1. `feat(core): notify the old address when an email change is requested`
2. `feat(core): add cancel link and completion notice to email change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
