### PR TITLE
feat(core): add session management endpoints (list/revoke)

### DIFF
--- a/adapters/chi/chi_adapter.go
+++ b/adapters/chi/chi_adapter.go
@@ -59,4 +59,8 @@ func InitAuth(ac *core.AuthClient, r *chi.Mux) {
 	r.Method(http.MethodPost, core.PathLogout, mw(ac.LogoutHandler()))
 	r.Method(http.MethodPost, core.PathChangePassword, mw(ac.ChangePasswordHandler()))
 	r.Method(http.MethodPost, core.PathChangeEmail, mw(ac.ChangeEmailHandler()))
+
+	r.Method(http.MethodGet, core.PathSessions, mw(ac.ListSessionsHandler()))
+	r.Method(http.MethodDelete, core.PathSessions, mw(ac.RevokeOtherSessionsHandler()))
+	r.Method(http.MethodDelete, core.PathSession, mw(ac.RevokeSessionHandler()))
 }

--- a/adapters/conformance/conformance_test.go
+++ b/adapters/conformance/conformance_test.go
@@ -121,6 +121,9 @@ func Test_Conformance_AdaptersRegisterAllRoutes(t *testing.T) {
 		{http.MethodPost, core.PathLogout},
 		{http.MethodPost, core.PathChangePassword},
 		{http.MethodPost, core.PathChangeEmail},
+		{http.MethodGet, core.PathSessions},
+		{http.MethodDelete, core.PathSessions},
+		{http.MethodDelete, strings.Replace(core.PathSession, "{id}", "conformance-session-id", 1)},
 	}
 
 	for name, probe := range probers {

--- a/adapters/echo/echo_adapter.go
+++ b/adapters/echo/echo_adapter.go
@@ -60,4 +60,8 @@ func InitAuth(ac *core.AuthClient, e *echo.Echo) {
 	e.POST(core.PathLogout, echo.WrapHandler(mw(ac.LogoutHandler())))
 	e.POST(core.PathChangePassword, echo.WrapHandler(mw(ac.ChangePasswordHandler())))
 	e.POST(core.PathChangeEmail, echo.WrapHandler(mw(ac.ChangeEmailHandler())))
+
+	e.GET(core.PathSessions, echo.WrapHandler(mw(ac.ListSessionsHandler())))
+	e.DELETE(core.PathSessions, echo.WrapHandler(mw(ac.RevokeOtherSessionsHandler())))
+	e.DELETE(core.ColonParamPattern(core.PathSession), echo.WrapHandler(mw(ac.RevokeSessionHandler())))
 }

--- a/adapters/fiber/fiber_adapter.go
+++ b/adapters/fiber/fiber_adapter.go
@@ -58,4 +58,8 @@ func InitAuth(ac *core.AuthClient, app *fiber.App) {
 	app.Post(core.PathLogout, adaptor.HTTPHandler(mw(ac.LogoutHandler())))
 	app.Post(core.PathChangePassword, adaptor.HTTPHandler(mw(ac.ChangePasswordHandler())))
 	app.Post(core.PathChangeEmail, adaptor.HTTPHandler(mw(ac.ChangeEmailHandler())))
+
+	app.Get(core.PathSessions, adaptor.HTTPHandler(mw(ac.ListSessionsHandler())))
+	app.Delete(core.PathSessions, adaptor.HTTPHandler(mw(ac.RevokeOtherSessionsHandler())))
+	app.Delete(core.ColonParamPattern(core.PathSession), adaptor.HTTPHandler(mw(ac.RevokeSessionHandler())))
 }

--- a/adapters/gin/gin_adapter.go
+++ b/adapters/gin/gin_adapter.go
@@ -57,4 +57,8 @@ func InitAuth(ac *core.AuthClient, r *gin.Engine) {
 	r.POST(core.PathLogout, gin.WrapH(mw(ac.LogoutHandler())))
 	r.POST(core.PathChangePassword, gin.WrapH(mw(ac.ChangePasswordHandler())))
 	r.POST(core.PathChangeEmail, gin.WrapH(mw(ac.ChangeEmailHandler())))
+
+	r.GET(core.PathSessions, gin.WrapH(mw(ac.ListSessionsHandler())))
+	r.DELETE(core.PathSessions, gin.WrapH(mw(ac.RevokeOtherSessionsHandler())))
+	r.DELETE(core.ColonParamPattern(core.PathSession), gin.WrapH(mw(ac.RevokeSessionHandler())))
 }

--- a/adapters/gorilla/gorilla_adapter.go
+++ b/adapters/gorilla/gorilla_adapter.go
@@ -59,4 +59,8 @@ func InitAuth(ac *core.AuthClient, r *mux.Router) {
 	r.Handle(core.PathLogout, mw(ac.LogoutHandler())).Methods(http.MethodPost)
 	r.Handle(core.PathChangePassword, mw(ac.ChangePasswordHandler())).Methods(http.MethodPost)
 	r.Handle(core.PathChangeEmail, mw(ac.ChangeEmailHandler())).Methods(http.MethodPost)
+
+	r.Handle(core.PathSessions, mw(ac.ListSessionsHandler())).Methods(http.MethodGet)
+	r.Handle(core.PathSessions, mw(ac.RevokeOtherSessionsHandler())).Methods(http.MethodDelete)
+	r.Handle(core.PathSession, mw(ac.RevokeSessionHandler())).Methods(http.MethodDelete)
 }

--- a/adapters/stdhttp/stdhttp_adapter.go
+++ b/adapters/stdhttp/stdhttp_adapter.go
@@ -56,4 +56,8 @@ func InitAuth(ac *core.AuthClient, mux *http.ServeMux) {
 	mux.Handle("POST "+core.PathLogout, mw(ac.LogoutHandler()))
 	mux.Handle("POST "+core.PathChangePassword, mw(ac.ChangePasswordHandler()))
 	mux.Handle("POST "+core.PathChangeEmail, mw(ac.ChangeEmailHandler()))
+
+	mux.Handle("GET "+core.PathSessions, mw(ac.ListSessionsHandler()))
+	mux.Handle("DELETE "+core.PathSessions, mw(ac.RevokeOtherSessionsHandler()))
+	mux.Handle("DELETE "+core.PathSession, mw(ac.RevokeSessionHandler()))
 }

--- a/core/internal/store/session.go
+++ b/core/internal/store/session.go
@@ -141,6 +141,82 @@ func (s *SessionStore) DeleteForUser(ctx context.Context, tx *sqlx.Tx, userID st
 	return nil
 }
 
+// ListForUser returns the user's currently-active (unexpired) sessions, newest first.
+// The Token field carries the stored hash, which callers use to flag the current
+// session; it is never serialised (json:"-").
+func (s *SessionStore) ListForUser(ctx context.Context, userID string) ([]*Session, error) {
+	query := `
+		SELECT * FROM sessions
+		WHERE user_id = $1 AND expires_at > NOW()
+		ORDER BY created_at DESC
+	`
+
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	sessions := []*Session{}
+	if err := s.db.SelectContext(ctx, &sessions, query, userID); err != nil {
+		return nil, err
+	}
+
+	return sessions, nil
+}
+
+// DeleteOthersForUser revokes every session for the user except the one identified by
+// currentToken (the raw token, hashed here for comparison), so the caller's own session
+// survives a "log out everywhere else" action.
+func (s *SessionStore) DeleteOthersForUser(ctx context.Context, tx *sqlx.Tx, userID, currentToken string) error {
+	query := `
+		DELETE FROM sessions WHERE user_id = $1 AND token <> $2
+	`
+
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	hashed := auth.HashToken(currentToken)
+	var err error
+	if tx != nil {
+		_, err = tx.ExecContext(ctx, query, userID, hashed)
+	} else {
+		_, err = s.db.ExecContext(ctx, query, userID, hashed)
+	}
+
+	return err
+}
+
+// DeleteByIDForUser revokes a single session by id, scoped to the owning user so one
+// user can't revoke another's session. It returns ErrNotFound when no such session
+// exists for the user (including when id isn't a valid UUID, which simply matches
+// nothing). The deleted row is returned so the caller can tell whether it revoked the
+// session backing the current request. The id is compared as text so a malformed value
+// can't raise a type error.
+func (s *SessionStore) DeleteByIDForUser(ctx context.Context, tx *sqlx.Tx, userID, id string) (*Session, error) {
+	query := `
+		DELETE FROM sessions
+		WHERE user_id = $1 AND id::text = $2
+		RETURNING *
+	`
+
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	session := &Session{}
+	var err error
+	if tx != nil {
+		err = tx.GetContext(ctx, session, query, userID, id)
+	} else {
+		err = s.db.GetContext(ctx, session, query, userID, id)
+	}
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	return session, nil
+}
+
 func (s *SessionStore) DeleteExpired(ctx context.Context) error {
 	query := `DELETE FROM sessions WHERE expires_at < NOW()`
 

--- a/core/internal/store/store.go
+++ b/core/internal/store/store.go
@@ -29,6 +29,9 @@ type Storage struct {
 		Refresh(ctx context.Context, tx *sqlx.Tx, oldToken string, expiresAt time.Time) (string, error)
 		Delete(ctx context.Context, tx *sqlx.Tx, token string) error
 		DeleteForUser(ctx context.Context, tx *sqlx.Tx, userID string) error
+		ListForUser(ctx context.Context, userID string) ([]*Session, error)
+		DeleteOthersForUser(ctx context.Context, tx *sqlx.Tx, userID, currentToken string) error
+		DeleteByIDForUser(ctx context.Context, tx *sqlx.Tx, userID, id string) (*Session, error)
 		DeleteExpired(ctx context.Context) error
 	}
 	Verification interface {

--- a/core/routes.go
+++ b/core/routes.go
@@ -25,6 +25,8 @@ const (
 	PathChangeEmail        = "/auth/change-email"
 	PathConfirmEmailChange = "/auth/change-email/{token}"
 	PathCancelEmailChange  = "/auth/change-email/{token}/cancel"
+	PathSessions           = "/auth/sessions"
+	PathSession            = "/auth/sessions/{id}"
 )
 
 // ColonParamPattern converts a canonical "{name}" path pattern to the ":name" form

--- a/core/session_handlers.go
+++ b/core/session_handlers.go
@@ -1,0 +1,126 @@
+package core
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AdrianTworek/go-auth/core/internal/auth"
+	"github.com/AdrianTworek/go-auth/core/internal/store"
+)
+
+// sessionView is the safe projection of a session returned by the list endpoint. It
+// deliberately omits the stored token hash and exposes only what a user needs to
+// recognise a device ("is this me?", where and when it signed in).
+type sessionView struct {
+	ID        string    `json:"id"`
+	IPAddress string    `json:"ipAddress"`
+	UserAgent string    `json:"userAgent"`
+	CreatedAt time.Time `json:"createdAt"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	// Current marks the session backing this very request, so a UI can label it and
+	// avoid offering to revoke the device the user is on.
+	Current bool `json:"current"`
+}
+
+// ListSessionsHandler returns the authenticated user's active sessions, newest first,
+// with the current session flagged. It must be mounted behind AuthMiddleware.
+func (ac *AuthClient) ListSessionsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := getUserFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+		currentToken, _ := getSessionTokenFromContext(r)
+		currentHash := auth.HashToken(currentToken)
+
+		sessions, err := ac.store.Session.ListForUser(r.Context(), user.ID)
+		if err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		views := make([]sessionView, 0, len(sessions))
+		for _, s := range sessions {
+			views = append(views, sessionView{
+				ID:        s.ID,
+				IPAddress: s.IPAddress,
+				UserAgent: s.UserAgent,
+				CreatedAt: s.CreatedAt,
+				ExpiresAt: s.ExpiresAt,
+				Current:   s.Token == currentHash,
+			})
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"sessions": views})
+	}
+}
+
+// RevokeOtherSessionsHandler logs the user out of every device except the current one
+// ("sign out everywhere else"). It must be mounted behind AuthMiddleware.
+func (ac *AuthClient) RevokeOtherSessionsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := getUserFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+		currentToken, ok := getSessionTokenFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+
+		if err := ac.store.Session.DeleteOthersForUser(r.Context(), nil, user.ID, currentToken); err != nil {
+			serverError(w, r, err)
+			return
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "All other sessions have been revoked"})
+	}
+}
+
+// RevokeSessionHandler revokes one of the user's sessions by id (e.g. "sign out this
+// other device"). It must be mounted behind AuthMiddleware.
+//
+// The id is read from the request path rather than through a ParamExtractor: the route
+// is always mounted at PathSession, so trimming that fixed prefix yields the id and
+// lets every adapter register this route exactly like the other protected routes,
+// without a per-framework param-extraction closure. Deletion is scoped to the caller's
+// user id, so one user can't revoke another's session (an unknown id returns 404).
+func (ac *AuthClient) RevokeSessionHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := getUserFromContext(r)
+		if !ok {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+		currentToken, _ := getSessionTokenFromContext(r)
+
+		id := strings.TrimPrefix(r.URL.Path, PathSessions+"/")
+		if id == "" || strings.Contains(id, "/") {
+			writeJSONError(w, http.StatusBadRequest, "Session id is required")
+			return
+		}
+
+		deleted, err := ac.store.Session.DeleteByIDForUser(r.Context(), nil, user.ID, id)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				writeJSONError(w, http.StatusNotFound, "Session not found")
+				return
+			}
+			serverError(w, r, err)
+			return
+		}
+
+		// Revoking the session behind this request logs the caller out, so clear the
+		// cookie as well.
+		if deleted.Token == auth.HashToken(currentToken) {
+			http.SetCookie(w, ac.deleteSessionCookie())
+		}
+
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": "Session revoked"})
+	}
+}

--- a/core/session_management_test.go
+++ b/core/session_management_test.go
@@ -1,0 +1,277 @@
+package core
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AdrianTworek/go-auth/core/internal/auth"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// sessionIDByToken resolves the id of the session backing a raw session token, by
+// looking it up via the stored hash.
+func sessionIDByToken(t *testing.T, db *sql.DB, rawToken string) string {
+	t.Helper()
+	var id string
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT id FROM sessions WHERE token = $1`, auth.HashToken(rawToken)).Scan(&id))
+	return id
+}
+
+func doDelete(t *testing.T, app *TestApp, path string, cookie *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	rr := httptest.NewRecorder()
+	app.Router().ServeHTTP(rr, req)
+	return rr
+}
+
+type sessionListResponse struct {
+	Data struct {
+		Sessions []struct {
+			ID        string `json:"id"`
+			IPAddress string `json:"ipAddress"`
+			UserAgent string `json:"userAgent"`
+			Current   bool   `json:"current"`
+		} `json:"sessions"`
+	} `json:"data"`
+}
+
+func decodeSessionList(t *testing.T, rr *httptest.ResponseRecorder) sessionListResponse {
+	t.Helper()
+	var resp sessionListResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	return resp
+}
+
+// --- list ------------------------------------------------------------------
+
+func Test_Integration_ListSessions(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// A second device for the same user.
+	uid := userID(t, db, TestUserData[DefaultUser].Email)
+	other := sessionCookieFor(t, app, uid)
+
+	rr := doGet(t, app, PathSessions, cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	resp := decodeSessionList(t, rr)
+	require.Len(t, resp.Data.Sessions, 2)
+
+	// Exactly one session is flagged current, and it's the one behind this request.
+	currentID := sessionIDByToken(t, db, cookie.Value)
+	currentCount := 0
+	for _, s := range resp.Data.Sessions {
+		if s.Current {
+			currentCount++
+			assert.Equal(t, currentID, s.ID)
+		}
+	}
+	assert.Equal(t, 1, currentCount)
+
+	// The other device is present and not flagged current.
+	otherID := sessionIDByToken(t, db, other.Value)
+	found := false
+	for _, s := range resp.Data.Sessions {
+		if s.ID == otherID {
+			found = true
+			assert.False(t, s.Current)
+		}
+	}
+	assert.True(t, found, "the second device's session should be listed")
+}
+
+func Test_Integration_ListSessionsRequiresAuth(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doGet(t, app, PathSessions, nil)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// --- revoke others ---------------------------------------------------------
+
+func Test_Integration_RevokeOtherSessions(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	uid := userID(t, db, TestUserData[DefaultUser].Email)
+	other1 := sessionCookieFor(t, app, uid)
+	other2 := sessionCookieFor(t, app, uid)
+
+	rr := doDelete(t, app, PathSessions, cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The current session still works; the other two are gone.
+	_, err := app.storage.Session.Validate(t.Context(), nil, cookie.Value)
+	assert.NoError(t, err)
+	_, err = app.storage.Session.Validate(t.Context(), nil, other1.Value)
+	assert.Error(t, err)
+	_, err = app.storage.Session.Validate(t.Context(), nil, other2.Value)
+	assert.Error(t, err)
+}
+
+func Test_Integration_RevokeOtherSessionsRequiresAuth(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doDelete(t, app, PathSessions, nil)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// --- revoke one by id ------------------------------------------------------
+
+func Test_Integration_RevokeSessionByID(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	uid := userID(t, db, TestUserData[DefaultUser].Email)
+	other := sessionCookieFor(t, app, uid)
+	otherID := sessionIDByToken(t, db, other.Value)
+
+	rr := doDelete(t, app, strings.Replace(PathSession, "{id}", otherID, 1), cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The targeted session is revoked; the caller's own session is untouched, and no
+	// logout cookie is issued (a different device was revoked).
+	_, err := app.storage.Session.Validate(t.Context(), nil, other.Value)
+	assert.Error(t, err)
+	_, err = app.storage.Session.Validate(t.Context(), nil, cookie.Value)
+	assert.NoError(t, err)
+	assert.Nil(t, helper.GetSessionCookie(rr))
+}
+
+// Revoking the current session by id logs the caller out: the session is gone and the
+// response clears the cookie.
+func Test_Integration_RevokeCurrentSessionByIDClearsCookie(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+	currentID := sessionIDByToken(t, db, cookie.Value)
+
+	rr := doDelete(t, app, strings.Replace(PathSession, "{id}", currentID, 1), cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	_, err := app.storage.Session.Validate(t.Context(), nil, cookie.Value)
+	assert.Error(t, err)
+
+	cleared := helper.GetSessionCookie(rr)
+	require.NotNil(t, cleared, "revoking the current session should clear the cookie")
+	assert.Empty(t, cleared.Value)
+}
+
+// A user can't revoke another user's session: it's scoped to the caller, so an id that
+// belongs to someone else is indistinguishable from a non-existent one (404).
+func Test_Integration_RevokeSessionByIDOtherUserForbidden(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// A session owned by a different user.
+	victimID := userID(t, db, TestUserData[UnverifiedUser].Email)
+	victim := sessionCookieFor(t, app, victimID)
+	victimSessionID := sessionIDByToken(t, db, victim.Value)
+
+	rr := doDelete(t, app, strings.Replace(PathSession, "{id}", victimSessionID, 1), cookie)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+	// The victim's session is still valid.
+	_, err := app.storage.Session.Validate(t.Context(), nil, victim.Value)
+	assert.NoError(t, err)
+}
+
+func Test_Integration_RevokeSessionByIDNotFound(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// A well-formed but unknown UUID, and a malformed id, both resolve to 404 without
+	// leaking whether the id was valid.
+	unknown := "00000000-0000-0000-0000-000000000000"
+	rr := doDelete(t, app, strings.Replace(PathSession, "{id}", unknown, 1), cookie)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+	rr = doDelete(t, app, strings.Replace(PathSession, "{id}", "not-a-uuid", 1), cookie)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func Test_Integration_RevokeSessionByIDRequiresAuth(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	rr := doDelete(t, app, strings.Replace(PathSession, "{id}", "some-id", 1), nil)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// Only the caller's own sessions are listed (never another user's).
+func Test_Integration_ListSessionsScopedToUser(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// Another user with an active session that must not appear in the listing.
+	otherUserID := userID(t, db, TestUserData[UnverifiedUser].Email)
+	_ = sessionCookieFor(t, app, otherUserID)
+
+	rr := doGet(t, app, PathSessions, cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	resp := decodeSessionList(t, rr)
+	require.Len(t, resp.Data.Sessions, 1)
+	assert.Equal(t, sessionIDByToken(t, db, cookie.Value), resp.Data.Sessions[0].ID)
+}
+
+// Expired sessions are excluded from the listing.
+func Test_Integration_ListSessionsExcludesExpired(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	helper := newTestHelper(t, app)
+	cookie := loginCookie(t, helper, DefaultUser)
+
+	// Insert an already-expired session for the same user directly.
+	uid := userID(t, db, TestUserData[DefaultUser].Email)
+	_, err := db.ExecContext(t.Context(),
+		`INSERT INTO sessions (user_id, token, expires_at, ip_address, user_agent)
+		 VALUES ($1, $2, $3, '', '')`,
+		uid, auth.HashToken("expired-token"), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+
+	rr := doGet(t, app, PathSessions, cookie)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	resp := decodeSessionList(t, rr)
+	require.Len(t, resp.Data.Sessions, 1, "expired sessions must not be listed")
+	assert.Equal(t, sessionIDByToken(t, db, cookie.Value), resp.Data.Sessions[0].ID)
+}

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -153,6 +153,10 @@ func (a *TestApp) Router() *chi.Mux {
 	r.With(mw).Post(PathChangePassword, ac.ChangePasswordHandler())
 	r.With(mw).Post(PathChangeEmail, ac.ChangeEmailHandler())
 
+	r.With(mw).Get(PathSessions, ac.ListSessionsHandler())
+	r.With(mw).Delete(PathSessions, ac.RevokeOtherSessionsHandler())
+	r.With(mw).Delete(PathSession, ac.RevokeSessionHandler())
+
 	return r
 }
 


### PR DESCRIPTION
## Summary

Adds session-management endpoints so an authenticated user can see and revoke their active sessions — the "active devices / sign out everywhere" flow.

| Method & path | Behaviour |
|---|---|
| `GET /auth/sessions` | Lists the user's active (unexpired) sessions, newest first. The **current** session is flagged (`"current": true`). The stored token hash is never serialised — the response exposes only `id`, `ipAddress`, `userAgent`, `createdAt`, `expiresAt`. |
| `DELETE /auth/sessions` | "Sign out everywhere else" — revokes every session for the user **except** the current one. |
| `DELETE /auth/sessions/{id}` | Revokes a single session by id, **scoped to the caller**. Revoking your own current session also clears the session cookie. |

All three are mounted behind `AuthMiddleware`.

## Design notes

- **Ownership is enforced in SQL, not just checked.** Every list/revoke query is scoped by `user_id`, so a session belonging to another user, an unknown id, *or* a malformed id are all indistinguishable and return **404**. Revoke-by-id runs `DELETE ... WHERE user_id = $1 AND id::text = $2 RETURNING *`, which (a) makes a non-UUID simply match nothing instead of raising a Postgres type error, and (b) returns the deleted row so the handler can detect when it revoked the session behind the current request and clear the cookie.
- **Revoke-one reads the id from `r.URL.Path`** (trimming the fixed `PathSessions` prefix) rather than through a `ParamExtractor`. This is deliberate: it lets all six adapters register the route as a plain `mw(handler)` — identical to `/auth/logout` — with no protected-plus-param closure, keeping the per-framework adapters uniform and simple.
- No routing conflict: `/auth/sessions` (leaf) and `/auth/sessions/{id}` (param child) don't collide in httprouter/gin. The adapter conformance test asserts all six frameworks serve all three routes.

## Store

`Storage.Session` (internal) gains `ListForUser`, `DeleteOthersForUser`, and `DeleteByIDForUser`.

## Tests

11 new integration tests: list (with current-flagging, per-user scoping, expired excluded), revoke-others, revoke-by-id (including current-session-clears-cookie, cross-user → 404, unknown/malformed id → 404), and auth-required on each endpoint. Full core suite, adapter conformance, `golangci-lint`, `go vet` and `gofmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
