### PR TITLE
feat: add rate limiting, proxy-aware client IP, and SMTP mailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ bin/
 database/
 # .DS_Store
 .DS_Store
+# AI working docs (local roadmap/context, not committed)
+/ai-docs/

--- a/cmd/migrate/migrations/000002_rate_limits_and_session_index.down.sql
+++ b/cmd/migrate/migrations/000002_rate_limits_and_session_index.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS "rate_limits";
+DROP INDEX IF EXISTS "sessions_user_id";

--- a/cmd/migrate/migrations/000002_rate_limits_and_session_index.up.sql
+++ b/cmd/migrate/migrations/000002_rate_limits_and_session_index.up.sql
@@ -1,0 +1,13 @@
+-- Index session lookups by user_id. ListForUser / DeleteForUser /
+-- DeleteOthersForUser / DeleteByIDForUser all filter on user_id and were
+-- sequential scans without this.
+CREATE INDEX IF NOT EXISTS "sessions_user_id" ON "sessions" (user_id);
+
+-- Backing table for the optional Postgres rate-limit store (token bucket). One row
+-- per rate-limit key; "tokens" is the current bucket level and "updated_at" is when
+-- it was last refilled/consumed. Rows for idle keys are pruned by DeleteStale.
+CREATE TABLE IF NOT EXISTS "rate_limits" (
+  key VARCHAR(255) PRIMARY KEY,
+  tokens DOUBLE PRECISION NOT NULL,
+  updated_at TIMESTAMP(3) WITH TIME ZONE NOT NULL DEFAULT NOW()
+);

--- a/core/auth_client.go
+++ b/core/auth_client.go
@@ -17,11 +17,14 @@ import (
 )
 
 type AuthClient struct {
-	config     *AuthConfig
-	store      *store.Storage
-	hookStore  *HookStore
-	cookieOpts auth.CookieOptions
-	durations  resolvedDurations
+	config       *AuthConfig
+	store        *store.Storage
+	hookStore    *HookStore
+	cookieOpts   auth.CookieOptions
+	durations    resolvedDurations
+	limiter      RateLimiter
+	rl           resolvedRateLimit
+	trustedProxy *TrustedProxyConfig
 }
 
 // resolvedDurations holds the session and token lifetimes for an AuthClient with
@@ -174,12 +177,18 @@ func NewAuthClient(config *AuthConfig) (*AuthClient, error) {
 		hookStore = NewHookStore(HookMap{})
 	}
 
+	storage := store.NewStorage(db)
+	rl := resolveRateLimitRules(config.RateLimit)
+
 	return &AuthClient{
-		config:     config,
-		store:      store.NewStorage(db),
-		hookStore:  hookStore,
-		cookieOpts: resolveCookieOptions(config.Session),
-		durations:  resolveDurations(config.Session, config.Tokens),
+		config:       config,
+		store:        storage,
+		hookStore:    hookStore,
+		cookieOpts:   resolveCookieOptions(config.Session),
+		durations:    resolveDurations(config.Session, config.Tokens),
+		rl:           rl,
+		limiter:      buildRateLimiter(config.RateLimit, storage, rl),
+		trustedProxy: config.TrustedProxy,
 	}, nil
 }
 
@@ -235,5 +244,10 @@ func (ac *AuthClient) CleanupExpired(ctx context.Context) error {
 	if err := ac.store.Session.DeleteExpired(ctx); err != nil {
 		return err
 	}
-	return ac.store.Verification.DeleteExpired(ctx)
+	if err := ac.store.Verification.DeleteExpired(ctx); err != nil {
+		return err
+	}
+	// Prune idle rate-limit buckets (Postgres backend only; a no-op-ish DELETE that
+	// matches nothing when the in-memory backend is used).
+	return ac.store.RateLimit.DeleteStale(ctx)
 }

--- a/core/config.go
+++ b/core/config.go
@@ -29,6 +29,19 @@ type AuthConfig struct {
 	//
 	// Default: 10
 	BcryptCost int
+	// RateLimit configures abuse protection on the auth endpoints (brute-force and
+	// email flooding). When nil, rate limiting is ON with conservative defaults and
+	// an in-memory store — correct for a single instance. See RateLimitConfig.
+	//
+	// Default: enabled, in-memory
+	RateLimit *RateLimitConfig
+	// TrustedProxy controls how the client IP is derived for rate limiting and
+	// session records. When nil the library uses the direct peer (RemoteAddr), which
+	// is correct when the app is exposed directly. Set it when behind a proxy or load
+	// balancer so the real client IP is read from X-Forwarded-For.
+	//
+	// Default: nil (use RemoteAddr)
+	TrustedProxy *TrustedProxyConfig
 }
 
 type OAuthConfig struct {
@@ -126,4 +139,100 @@ type TokenConfig struct {
 	//
 	// Default: 5 minutes
 	EmailChange time.Duration
+}
+
+// RateLimitBackend selects a built-in counter store for rate limiting.
+type RateLimitBackend int
+
+const (
+	// RateLimitMemory keeps counters in process. It is the default and is correct
+	// for a single instance, but limits are per-process (N replicas = N times the
+	// limit) and reset on restart.
+	RateLimitMemory RateLimitBackend = iota
+	// RateLimitPostgres keeps counters in Postgres (using the library's existing
+	// pool), so limits are shared and authoritative across replicas. Use it when you
+	// run more than one instance.
+	RateLimitPostgres
+)
+
+// RateLimitConfig tunes abuse protection on the auth endpoints. A nil RateLimitConfig
+// enables the built-in defaults; set Enabled to a pointer to false to turn protection
+// off entirely.
+//
+// Limits are enforced with a token-bucket algorithm derived from each Rule's
+// {Max, Window}: a burst of up to Max is allowed, refilling to full over Window. Over
+// the limit, callers receive HTTP 429 with a Retry-After header — except the
+// per-account cap on the email-sending endpoints, which stays silent (the generic 200
+// response is unchanged and the extra email is dropped) so it can't be used to
+// enumerate accounts.
+type RateLimitConfig struct {
+	// Enabled toggles all rate limiting. When nil it defaults to true.
+	//
+	// Default: true
+	Enabled *bool
+	// Backend selects a built-in counter store (in-memory or Postgres). Ignored when
+	// Store is set.
+	//
+	// Default: RateLimitMemory
+	Backend RateLimitBackend
+	// Store plugs in a custom RateLimiter (e.g. Redis), overriding Backend.
+	//
+	// Default: nil (use Backend)
+	Store RateLimiter
+	// Login throttles failed password logins, keyed on client IP and on the targeted
+	// account. A successful login clears the account counter.
+	//
+	// Default: 10 / 15m per IP, 5 / 15m per account
+	Login Rule
+	// SendEmail throttles the address-sending endpoints (password reset,
+	// resend-verification, magic link) to curb email flooding.
+	//
+	// Default: 20 / 1h per IP, 3 / 1h per account
+	SendEmail Rule
+	// Register throttles account creation. Keyed on client IP (PerAccount is unused).
+	//
+	// Default: 10 / 1h per IP
+	Register Rule
+	// Sensitive throttles authenticated re-authentication actions (change password,
+	// change email), keyed on client IP and on the acting user.
+	//
+	// Default: 20 / 1h per IP, 10 / 1h per user
+	Sensitive Rule
+}
+
+// Rule is a per-flow limit with two independent dimensions. A zero-valued Limit uses
+// the flow's default; set a Limit's Max to a negative number to disable that
+// dimension.
+type Rule struct {
+	// PerIP caps requests from a single client IP (catches spray / stuffing).
+	PerIP Limit
+	// PerAccount caps requests targeting a single account or user (catches a focused
+	// attack on one victim). Unused by the Register flow.
+	PerAccount Limit
+}
+
+// Limit is one token-bucket limit: at most Max requests per Window.
+type Limit struct {
+	// Max is the burst size and the number of requests allowed per Window. Zero uses
+	// the default; a negative value disables this dimension.
+	Max int
+	// Window is the period over which the bucket refills to full. Zero uses the
+	// default.
+	Window time.Duration
+}
+
+// TrustedProxyConfig controls client-IP resolution when the app runs behind a
+// proxy or load balancer. Only enable this for infrastructure you control:
+// X-Forwarded-For is client-supplied and trivially spoofable otherwise.
+type TrustedProxyConfig struct {
+	// TrustForwardedHeader turns on X-Forwarded-For parsing. When false the direct
+	// peer (RemoteAddr) is always used.
+	TrustForwardedHeader bool
+	// TrustedHops is how many trusted proxies sit in front of the app. The client IP
+	// is taken that many entries from the right of the forwarded chain, so a
+	// client-supplied left-most value can't be trusted. For a single load balancer,
+	// set this to 1.
+	//
+	// Default: 0
+	TrustedHops int
 }

--- a/core/handlers.go
+++ b/core/handlers.go
@@ -37,6 +37,10 @@ func (ac *AuthClient) RegisterHandler() http.HandlerFunc {
 			return
 		}
 
+		if !ac.guardRegister(w, r) {
+			return
+		}
+
 		newUser := store.NewUser(req.Email, false, nil, nil, nil, nil)
 		if err := newUser.Password.Set(req.Password); err != nil {
 			serverError(w, r, err)
@@ -187,6 +191,13 @@ func (ac *AuthClient) LoginHandler() http.HandlerFunc {
 			return
 		}
 
+		// Throttle before touching bcrypt so a flood can't exhaust CPU. Keyed on
+		// client IP and on the submitted email (whether or not it's a real account,
+		// so a 429 never reveals account existence).
+		if !ac.guardLogin(w, r, req.Email) {
+			return
+		}
+
 		cont, err := ac.hookStore.Trigger(
 			r.Context(),
 			NewAuthEvent(
@@ -222,6 +233,10 @@ func (ac *AuthClient) LoginHandler() http.HandlerFunc {
 			writeJSONError(w, http.StatusUnauthorized, "Invalid credentials")
 			return
 		}
+
+		// Correct password: clear the per-account throttle so earlier typos don't
+		// leave a legitimate user rate-limited.
+		ac.resetLoginLimit(r.Context(), req.Email)
 
 		if ac.config.Session.RequireVerifiedEmail && !user.EmailVerified {
 			writeJSONError(w, http.StatusForbidden, "You need to verify your email before logging in. Please check your email for a verification link.")
@@ -464,6 +479,10 @@ func (ac *AuthClient) ResendVerificationHandler() http.HandlerFunc {
 			return
 		}
 
+		if !ac.guardSend(w, r, "resend_verification", req.Email, genericVerificationMessage) {
+			return
+		}
+
 		// respond is used for every non-error outcome so registered, unregistered and
 		// already-verified addresses are indistinguishable from the response.
 		respond := func() {
@@ -552,6 +571,10 @@ func (ac *AuthClient) SendMagicLinkHandler() http.HandlerFunc {
 		var req request
 		if err := readAndValidateJSON(w, r, &req); err != nil {
 			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if !ac.guardSend(w, r, "magic_link", req.Email, "Magic link sent") {
 			return
 		}
 
@@ -744,6 +767,10 @@ func (ac *AuthClient) SendPasswordResetLinkHandler() http.HandlerFunc {
 			return
 		}
 
+		if !ac.guardSend(w, r, "reset_password", req.Email, genericResetMessage) {
+			return
+		}
+
 		user, err := ac.store.User.GetByEmail(r.Context(), nil, req.Email)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
@@ -923,6 +950,10 @@ func (ac *AuthClient) ChangePasswordHandler() http.HandlerFunc {
 			return
 		}
 
+		if !ac.guardSensitive(w, r, "change_password", user.ID) {
+			return
+		}
+
 		// OAuth-only and magic-link-only accounts have no password to change. Direct
 		// them to the password-reset flow, which can set a first password.
 		if len(user.Password) == 0 {
@@ -1021,6 +1052,10 @@ func (ac *AuthClient) ChangeEmailHandler() http.HandlerFunc {
 		var req request
 		if err := readAndValidateJSON(w, r, &req); err != nil {
 			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if !ac.guardSensitive(w, r, "change_email", user.ID) {
 			return
 		}
 

--- a/core/hooks.go
+++ b/core/hooks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/AdrianTworek/go-auth/core/internal/store"
 )
@@ -24,7 +25,29 @@ const (
 	EventEmailVerificationSuccess  AuthEventType = "email_verification_success"
 	EventEmailVerificationCallback AuthEventType = "email_verification_callback"
 	EventEmailVerificationFailed   AuthEventType = "email_verification_failed"
+	// EventRateLimited fires when a request is throttled by the rate limiter, before
+	// the 429 (or silent generic) response is written. The event's RateLimit field
+	// carries the details. It is primarily observational (logging, metrics, alerting);
+	// a hook may still respond early via the usual Hook* sentinels. Under an attack it
+	// can fire frequently, so keep handlers cheap.
+	EventRateLimited AuthEventType = "rate_limited"
 )
+
+// RateLimitInfo describes a throttling event, exposed to EventRateLimited hooks.
+type RateLimitInfo struct {
+	// Flow is the endpoint family that was limited, e.g. "login", "register",
+	// "reset_password", "resend_verification", "magic_link", "change_password" or
+	// "change_email".
+	Flow string
+	// Dimension is which limit tripped: "ip", "account" or "user".
+	Dimension string
+	// Key is the internal limiter key that was exceeded (contains the IP, email or
+	// user id), useful for logging.
+	Key string
+	// RetryAfter is how long until the caller may retry. Zero for the silent
+	// per-account cap on send endpoints.
+	RetryAfter time.Duration
+}
 
 type AuthEvent struct {
 	// Type of event that was triggered like EventBeforeLogin
@@ -35,6 +58,8 @@ type AuthEvent struct {
 	W http.ResponseWriter
 	// Request object from the request the event was sent from
 	R *http.Request
+	// RateLimit is set only for EventRateLimited and describes the throttling event.
+	RateLimit *RateLimitInfo
 }
 
 func NewAuthEvent(eventType AuthEventType, w http.ResponseWriter, r *http.Request, user *store.User) *AuthEvent {

--- a/core/internal/store/ratelimit.go
+++ b/core/internal/store/ratelimit.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// RateLimitStore is the Postgres-backed token-bucket counter used when the library
+// runs across multiple replicas and needs shared, authoritative rate-limit state.
+// Each key maps to one row holding the current token level and when it was last
+// touched; refill is computed from elapsed time on read.
+type RateLimitStore struct {
+	db *sqlx.DB
+}
+
+// Allow refills the bucket for key based on time elapsed since it was last updated,
+// then consumes one token if any are available. It reports whether the request is
+// allowed and, when not, how long until a token frees up.
+//
+// The read-modify-write runs in a transaction with SELECT ... FOR UPDATE so
+// concurrent requests on the same key serialize on the row and can't double-spend.
+// All timing is measured with the database clock (NOW()) so app/DB clock skew can't
+// distort the bucket.
+func (s *RateLimitStore) Allow(ctx context.Context, key string, capacity, refillPerSecond float64) (bool, time.Duration, error) {
+	if capacity <= 0 || refillPerSecond <= 0 {
+		return true, 0, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, 0, err
+	}
+	// Rollback is a no-op once the tx is committed; safe to always defer.
+	defer func() { _ = tx.Rollback() }()
+
+	// Ensure the row exists so the subsequent FOR UPDATE has something to lock. A
+	// brand-new bucket starts full.
+	if _, err = tx.ExecContext(ctx,
+		`INSERT INTO rate_limits (key, tokens, updated_at) VALUES ($1, $2, NOW())
+		 ON CONFLICT (key) DO NOTHING`, key, capacity); err != nil {
+		return false, 0, err
+	}
+
+	var tokens, elapsed float64
+	if err = tx.QueryRowxContext(ctx,
+		`SELECT tokens, EXTRACT(EPOCH FROM (NOW() - updated_at)) FROM rate_limits WHERE key = $1 FOR UPDATE`,
+		key).Scan(&tokens, &elapsed); err != nil {
+		return false, 0, err
+	}
+
+	if elapsed > 0 {
+		tokens = math.Min(capacity, tokens+elapsed*refillPerSecond)
+	}
+
+	allowed := tokens >= 1
+	var retryAfter time.Duration
+	if allowed {
+		tokens--
+	} else {
+		retryAfter = time.Duration((1 - tokens) / refillPerSecond * float64(time.Second))
+	}
+
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE rate_limits SET tokens = $1, updated_at = NOW() WHERE key = $2`, tokens, key); err != nil {
+		return false, 0, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return false, 0, err
+	}
+
+	return allowed, retryAfter, nil
+}
+
+// Reset clears the bucket for key (e.g. after a successful login), so the next
+// request starts from a full bucket.
+func (s *RateLimitStore) Reset(ctx context.Context, key string) error {
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	_, err := s.db.ExecContext(ctx, `DELETE FROM rate_limits WHERE key = $1`, key)
+	return err
+}
+
+// DeleteStale removes buckets untouched for a day. Such a bucket has long since
+// refilled to full, so it carries no state and dropping it is equivalent to keeping
+// it — this just stops the table growing unbounded. Call it periodically.
+func (s *RateLimitStore) DeleteStale(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+
+	_, err := s.db.ExecContext(ctx, `DELETE FROM rate_limits WHERE updated_at < NOW() - INTERVAL '1 day'`)
+	return err
+}

--- a/core/internal/store/store.go
+++ b/core/internal/store/store.go
@@ -45,6 +45,11 @@ type Storage struct {
 		Commit(tx *sqlx.Tx) error
 		Rollback(tx *sqlx.Tx) error
 	}
+	RateLimit interface {
+		Allow(ctx context.Context, key string, capacity, refillPerSecond float64) (allowed bool, retryAfter time.Duration, err error)
+		Reset(ctx context.Context, key string) error
+		DeleteStale(ctx context.Context) error
+	}
 }
 
 func NewStorage(db *sqlx.DB) *Storage {
@@ -53,5 +58,6 @@ func NewStorage(db *sqlx.DB) *Storage {
 		Session:      &SessionStore{db: db},
 		Verification: &VerificationStore{db: db},
 		Transaction:  &TransactionStore{db: db},
+		RateLimit:    &RateLimitStore{db: db},
 	}
 }

--- a/core/mailer/smtp.go
+++ b/core/mailer/smtp.go
@@ -1,0 +1,124 @@
+package mailer
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+)
+
+// SMTPConfig configures the reference SMTP mailer. It targets the common case of
+// an authenticated submission server on port 587 (STARTTLS) — SendGrid, Mailgun,
+// Amazon SES, Postmark and Gmail all support this. For a provider API or implicit
+// TLS (port 465), implement the Mailer interface yourself.
+type SMTPConfig struct {
+	// Host is the SMTP server hostname, e.g. "smtp.sendgrid.net".
+	Host string
+	// Port is the submission port. Defaults to "587" when empty.
+	Port string
+	// Username / Password authenticate to the server (PLAIN auth over STARTTLS).
+	Username string
+	Password string
+	// From is the envelope + header From address, e.g. "no-reply@example.com".
+	From string
+	// AppName, when set, is used in email subjects (e.g. "Verify your email for Acme").
+	AppName string
+	// BaseURL is the origin the emailed links point at (e.g. "https://example.com").
+	// It is joined with the library's auth paths to build verification/reset links.
+	BaseURL string
+}
+
+// SMTPMailer is a reference Mailer that delivers plain-text emails via net/smtp.
+// It exists so the email flows work end to end out of the box; production senders
+// will often replace it with a provider-specific implementation of Mailer.
+type SMTPMailer struct {
+	cfg SMTPConfig
+}
+
+// NewSMTP builds an SMTP-backed Mailer. It returns an error if the required
+// Host or From fields are missing, so misconfiguration fails fast at startup
+// rather than silently dropping every email.
+func NewSMTP(cfg SMTPConfig) (*SMTPMailer, error) {
+	if cfg.Host == "" {
+		return nil, errors.New("mailer: SMTP Host is required")
+	}
+	if cfg.From == "" {
+		return nil, errors.New("mailer: SMTP From is required")
+	}
+	if cfg.Port == "" {
+		cfg.Port = "587"
+	}
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+	return &SMTPMailer{cfg: cfg}, nil
+}
+
+// send delivers one plain-text message. smtp.SendMail upgrades the connection with
+// STARTTLS when the server advertises it, so credentials are not sent in the clear.
+func (m *SMTPMailer) send(to, subject, body string) error {
+	addr := net.JoinHostPort(m.cfg.Host, m.cfg.Port)
+	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "From: %s\r\n", m.cfg.From)
+	fmt.Fprintf(&b, "To: %s\r\n", to)
+	fmt.Fprintf(&b, "Subject: %s\r\n", subject)
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	b.WriteString("\r\n")
+	b.WriteString(body)
+
+	return smtp.SendMail(addr, auth, m.cfg.From, []string{to}, []byte(b.String()))
+}
+
+// subject decorates a subject line with the configured app name when present.
+func (m *SMTPMailer) subject(s string) string {
+	if m.cfg.AppName != "" {
+		return s + " for " + m.cfg.AppName
+	}
+	return s
+}
+
+func (m *SMTPMailer) link(path string) string {
+	return m.cfg.BaseURL + path
+}
+
+func (m *SMTPMailer) SendVerificationEmail(to, token string) error {
+	url := m.link("/auth/verify/" + token)
+	body := fmt.Sprintf("Welcome! Please confirm your email address by visiting:\n\n%s\n\nIf you did not create an account, you can ignore this message.", url)
+	return m.send(to, m.subject("Verify your email"), body)
+}
+
+func (m *SMTPMailer) SendPasswordResetEmail(to, token string) error {
+	url := m.link("/auth/reset-password/" + token)
+	body := fmt.Sprintf("We received a request to reset your password. Use the link below to choose a new one:\n\n%s\n\nIf you did not request this, you can safely ignore this email.", url)
+	return m.send(to, m.subject("Reset your password"), body)
+}
+
+func (m *SMTPMailer) SendPasswordChangedEmail(to string) error {
+	body := "Your password was just changed. If this was you, no action is needed. If it wasn't, reset your password immediately and review your active sessions."
+	return m.send(to, m.subject("Your password was changed"), body)
+}
+
+func (m *SMTPMailer) SendMagicLinkEmail(to, token string) error {
+	url := m.link("/auth/magic-link/" + token)
+	body := fmt.Sprintf("Here is your sign-in link:\n\n%s\n\nIt can only be used once and expires shortly. If you did not request it, you can ignore this email.", url)
+	return m.send(to, m.subject("Your sign-in link"), body)
+}
+
+func (m *SMTPMailer) SendEmailChangeEmail(to, token string) error {
+	url := m.link("/auth/change-email/" + token)
+	body := fmt.Sprintf("Please confirm your new email address by visiting:\n\n%s\n\nThe change only takes effect once you confirm.", url)
+	return m.send(to, m.subject("Confirm your new email"), body)
+}
+
+func (m *SMTPMailer) SendEmailChangeNotification(to, newEmail, cancelToken string) error {
+	url := m.link("/auth/change-email/" + cancelToken + "/cancel")
+	body := fmt.Sprintf("A request was made to change your account email to %s. If this was you, no action is needed — confirm using the link sent to the new address.\n\nIf this was NOT you, cancel the change here:\n\n%s", newEmail, url)
+	return m.send(to, m.subject("Email change requested"), body)
+}
+
+func (m *SMTPMailer) SendEmailChangeCompletedNotification(to, newEmail string) error {
+	body := fmt.Sprintf("Your account email was changed to %s. If you did not make this change, contact support immediately.", newEmail)
+	return m.send(to, m.subject("Your email was changed"), body)
+}

--- a/core/ratelimit.go
+++ b/core/ratelimit.go
@@ -1,0 +1,294 @@
+package core
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/AdrianTworek/go-auth/core/internal/store"
+)
+
+// RateLimiter records and checks request counts for abuse protection. The library
+// ships an in-memory implementation (default) and a Postgres-backed one, and callers
+// may plug in their own (e.g. Redis) via RateLimitConfig.Store.
+//
+// Allow records one hit against key and reports whether the caller is still under
+// limit; when not, retryAfter is how long until the next request would be allowed.
+// limit and window describe a token bucket (burst of limit, refilling to full over
+// window). Implementations MUST fail open — return allowed on their own internal
+// errors — so a limiter outage degrades to "no limiting" rather than an auth outage.
+type RateLimiter interface {
+	Allow(ctx context.Context, key string, limit int, window time.Duration) (allowed bool, retryAfter time.Duration, err error)
+	Reset(ctx context.Context, key string) error
+}
+
+// Built-in default limits, applied to any Rule field left at its zero value.
+var (
+	defaultLoginPerIP        = Limit{Max: 10, Window: 15 * time.Minute}
+	defaultLoginPerAccount   = Limit{Max: 5, Window: 15 * time.Minute}
+	defaultSendPerIP         = Limit{Max: 20, Window: time.Hour}
+	defaultSendPerAccount    = Limit{Max: 3, Window: time.Hour}
+	defaultRegisterPerIP     = Limit{Max: 10, Window: time.Hour}
+	defaultSensitivePerIP    = Limit{Max: 20, Window: time.Hour}
+	defaultSensitivePerActor = Limit{Max: 10, Window: time.Hour}
+)
+
+// resolvedLimit is a Limit with defaults applied. A disabled limit has limit <= 0.
+type resolvedLimit struct {
+	limit  int
+	window time.Duration
+}
+
+func (l resolvedLimit) enabled() bool { return l.limit > 0 && l.window > 0 }
+
+type resolvedRule struct {
+	perIP      resolvedLimit
+	perAccount resolvedLimit
+}
+
+// resolvedRateLimit holds the effective, defaulted rate-limit settings for an
+// AuthClient. When enabled is false the guards are no-ops.
+type resolvedRateLimit struct {
+	enabled   bool
+	login     resolvedRule
+	sendEmail resolvedRule
+	register  resolvedRule
+	sensitive resolvedRule
+}
+
+func resolveLimit(c, def Limit) resolvedLimit {
+	if c.Max < 0 {
+		return resolvedLimit{} // explicitly disabled
+	}
+	limit := c.Max
+	if limit == 0 {
+		limit = def.Max
+	}
+	window := c.Window
+	if window == 0 {
+		window = def.Window
+	}
+	return resolvedLimit{limit: limit, window: window}
+}
+
+func resolveRateLimitRules(cfg *RateLimitConfig) resolvedRateLimit {
+	enabled := true
+	var c RateLimitConfig
+	if cfg != nil {
+		c = *cfg
+		if cfg.Enabled != nil {
+			enabled = *cfg.Enabled
+		}
+	}
+	return resolvedRateLimit{
+		enabled: enabled,
+		login: resolvedRule{
+			perIP:      resolveLimit(c.Login.PerIP, defaultLoginPerIP),
+			perAccount: resolveLimit(c.Login.PerAccount, defaultLoginPerAccount),
+		},
+		sendEmail: resolvedRule{
+			perIP:      resolveLimit(c.SendEmail.PerIP, defaultSendPerIP),
+			perAccount: resolveLimit(c.SendEmail.PerAccount, defaultSendPerAccount),
+		},
+		register: resolvedRule{
+			perIP: resolveLimit(c.Register.PerIP, defaultRegisterPerIP),
+		},
+		sensitive: resolvedRule{
+			perIP:      resolveLimit(c.Sensitive.PerIP, defaultSensitivePerIP),
+			perAccount: resolveLimit(c.Sensitive.PerAccount, defaultSensitivePerActor),
+		},
+	}
+}
+
+// buildRateLimiter selects the RateLimiter implementation for the config. It returns
+// nil when limiting is disabled (the guards short-circuit on rl.enabled first, so the
+// limiter is never consulted).
+func buildRateLimiter(cfg *RateLimitConfig, s *store.Storage, rl resolvedRateLimit) RateLimiter {
+	if !rl.enabled {
+		return nil
+	}
+	if cfg != nil && cfg.Store != nil {
+		return cfg.Store
+	}
+	if cfg != nil && cfg.Backend == RateLimitPostgres {
+		return &postgresRateLimiter{store: s.RateLimit}
+	}
+	return newMemoryRateLimiter()
+}
+
+// clientIP derives the caller's IP for keying rate limits. It defaults to the direct
+// peer (RemoteAddr) and only consults X-Forwarded-For when a trusted-proxy config
+// opts in, taking the entry TrustedHops from the right of the chain so a spoofed
+// left-most value is ignored. On any ambiguity it falls back to the direct peer,
+// which is the safe (non-spoofable) choice.
+func (ac *AuthClient) clientIP(r *http.Request) string {
+	host := r.RemoteAddr
+	if h, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		host = h
+	}
+
+	tp := ac.trustedProxy
+	if tp == nil || !tp.TrustForwardedHeader {
+		return host
+	}
+
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return host
+	}
+
+	parts := strings.Split(xff, ",")
+	// chain is the forwarded addresses followed by the direct peer (RemoteAddr),
+	// which is always trustworthy. Build it fresh rather than appending onto parts.
+	chain := make([]string, 0, len(parts)+1)
+	for _, p := range parts {
+		chain = append(chain, strings.TrimSpace(p))
+	}
+	chain = append(chain, host)
+
+	idx := len(chain) - 1 - tp.TrustedHops
+	if idx < 0 || idx >= len(chain) || chain[idx] == "" {
+		return host
+	}
+	return chain[idx]
+}
+
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// check consumes one token for the given dimension and reports whether the request is
+// allowed. A disabled limit always allows. On limiter error it fails open.
+func (ac *AuthClient) check(ctx context.Context, flow, dimension, value string, l resolvedLimit) (RateLimitInfo, bool) {
+	if !l.enabled() {
+		return RateLimitInfo{}, true
+	}
+	key := flow + ":" + dimension + ":" + value
+	allowed, retryAfter, err := ac.limiter.Allow(ctx, key, l.limit, l.window)
+	if err != nil {
+		// Fail open: a limiter outage must not become an auth outage.
+		slog.Error("rate limiter failed, allowing request", "error", err, "flow", flow, "dimension", dimension)
+		return RateLimitInfo{}, true
+	}
+	return RateLimitInfo{Flow: flow, Dimension: dimension, Key: key, RetryAfter: retryAfter}, allowed
+}
+
+// fireRateLimitHook runs the EventRateLimited hook and reports whether the caller
+// should still write the default throttled response (true) or a hook already
+// responded (false).
+func (ac *AuthClient) fireRateLimitHook(w http.ResponseWriter, r *http.Request, info RateLimitInfo) bool {
+	ev := NewAuthEvent(EventRateLimited, w, r, nil)
+	ev.RateLimit = &info
+	cont, err := ac.hookStore.Trigger(r.Context(), ev)
+	if err != nil {
+		serverError(w, r, err)
+		return false
+	}
+	return cont
+}
+
+func (ac *AuthClient) write429(w http.ResponseWriter, retryAfter time.Duration) {
+	if retryAfter > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+	}
+	writeJSONError(w, http.StatusTooManyRequests, "Too many requests. Please slow down and try again later.")
+}
+
+// blocked429 fires the hook then (unless the hook responded) writes a 429. It always
+// returns false so callers can `return ac.blocked429(...)`.
+func (ac *AuthClient) blocked429(w http.ResponseWriter, r *http.Request, info RateLimitInfo) bool {
+	if ac.fireRateLimitHook(w, r, info) {
+		ac.write429(w, info.RetryAfter)
+	}
+	return false
+}
+
+// blockedSilent fires the hook then (unless the hook responded) writes the endpoint's
+// normal generic 200 while silently dropping the work — used for the per-account cap
+// on email-sending endpoints so throttling can't be used to enumerate accounts.
+func (ac *AuthClient) blockedSilent(w http.ResponseWriter, r *http.Request, info RateLimitInfo, genericMsg string) bool {
+	if ac.fireRateLimitHook(w, r, info) {
+		writeJSONResponse(w, http.StatusOK, map[string]any{"message": genericMsg})
+	}
+	return false
+}
+
+// --- per-flow guards -------------------------------------------------------
+//
+// Each guard returns true when the request may proceed, and false when it was
+// throttled (in which case the guard has already written the response).
+
+func (ac *AuthClient) guardLogin(w http.ResponseWriter, r *http.Request, email string) bool {
+	if !ac.rl.enabled {
+		return true
+	}
+	ctx := r.Context()
+	if info, ok := ac.check(ctx, "login", "ip", ac.clientIP(r), ac.rl.login.perIP); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	if info, ok := ac.check(ctx, "login", "account", normalizeEmail(email), ac.rl.login.perAccount); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	return true
+}
+
+// resetLoginLimit clears the per-account login counter after a successful login, so a
+// user who mistyped their password a few times isn't left throttled.
+func (ac *AuthClient) resetLoginLimit(ctx context.Context, email string) {
+	if !ac.rl.enabled || !ac.rl.login.perAccount.enabled() {
+		return
+	}
+	key := "login:account:" + normalizeEmail(email)
+	if err := ac.limiter.Reset(ctx, key); err != nil {
+		slog.Error("failed to reset login rate limit", "error", err)
+	}
+}
+
+func (ac *AuthClient) guardRegister(w http.ResponseWriter, r *http.Request) bool {
+	if !ac.rl.enabled {
+		return true
+	}
+	if info, ok := ac.check(r.Context(), "register", "ip", ac.clientIP(r), ac.rl.register.perIP); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	return true
+}
+
+// guardSend enforces the send-email rule: per-IP abuse gets a 429, but the per-account
+// cap stays silent (generic 200) to preserve anti-enumeration. flow namespaces the key
+// per endpoint so each has its own budget.
+func (ac *AuthClient) guardSend(w http.ResponseWriter, r *http.Request, flow, email, genericMsg string) bool {
+	if !ac.rl.enabled {
+		return true
+	}
+	ctx := r.Context()
+	if info, ok := ac.check(ctx, flow, "ip", ac.clientIP(r), ac.rl.sendEmail.perIP); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	if info, ok := ac.check(ctx, flow, "account", normalizeEmail(email), ac.rl.sendEmail.perAccount); !ok {
+		return ac.blockedSilent(w, r, info, genericMsg)
+	}
+	return true
+}
+
+// guardSensitive enforces the rule for authenticated re-auth actions, keyed on client
+// IP and on the acting user. Both dimensions return a 429 (the caller is already
+// authenticated, so there is no account to enumerate).
+func (ac *AuthClient) guardSensitive(w http.ResponseWriter, r *http.Request, flow, userID string) bool {
+	if !ac.rl.enabled {
+		return true
+	}
+	ctx := r.Context()
+	if info, ok := ac.check(ctx, flow, "ip", ac.clientIP(r), ac.rl.sensitive.perIP); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	if info, ok := ac.check(ctx, flow, "user", userID, ac.rl.sensitive.perAccount); !ok {
+		return ac.blocked429(w, r, info)
+	}
+	return true
+}

--- a/core/ratelimit_integration_test.go
+++ b/core/ratelimit_integration_test.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// rateLimitedClient builds an AuthClient against the test database with an explicit
+// rate-limit config, plus a fresh mailer mock. Unlike TestApp.Router() it is a single
+// persistent client, so its in-memory limiter (and any Postgres counters) survive
+// across the requests a test makes.
+func rateLimitedClient(t *testing.T, app *TestApp, rl *RateLimitConfig) (*AuthClient, *MockMailer) {
+	t.Helper()
+	m := &MockMailer{}
+	ac, err := NewAuthClient(&AuthConfig{
+		Db:            &DatabaseConfig{Dsn: app.env.DSN},
+		Mailer:        m,
+		Session:       &SessionConfig{},
+		SessionSecret: app.env.SessionSecret,
+		BaseURL:       "http://localhost",
+		RateLimit:     rl,
+	})
+	require.NoError(t, err)
+	return ac, m
+}
+
+// rlPost invokes a handler with a JSON body from the default httptest client IP
+// (192.0.2.1), so repeated calls share the same per-IP rate-limit key.
+func rlPost(t *testing.T, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+func loginBody(email, password string) string {
+	return fmt.Sprintf(`{"email":%q,"password":%q}`, email, password)
+}
+
+func Test_Integration_RateLimiting(t *testing.T) {
+	app, dbCtr, db := SetupIntegration(t, nil)
+	defer CleanupIntegration(t, dbCtr, db)
+
+	// Login: per-IP abuse returns 429 with a Retry-After header once the burst is
+	// spent (fires before bcrypt).
+	t.Run("LoginPerIPReturns429", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, &RateLimitConfig{
+			Login: Rule{
+				PerIP:      Limit{Max: 3, Window: time.Minute},
+				PerAccount: Limit{Max: 100, Window: time.Minute},
+			},
+		})
+		h := ac.LoginHandler()
+		body := loginBody("nobody@example.com", "wrong-password")
+
+		for i := 0; i < 3; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, body).Code, "attempt %d", i+1)
+		}
+		rr := rlPost(t, h, body)
+		require.Equal(t, http.StatusTooManyRequests, rr.Code)
+		require.NotEmpty(t, rr.Header().Get("Retry-After"))
+	})
+
+	// A successful login clears the per-account counter, so earlier failed attempts
+	// don't leave a legitimate user throttled.
+	t.Run("LoginResetOnSuccess", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, &RateLimitConfig{
+			Login: Rule{
+				PerIP:      Limit{Max: -1}, // isolate the per-account dimension
+				PerAccount: Limit{Max: 3, Window: time.Minute},
+			},
+		})
+		h := ac.LoginHandler()
+		email := TestUserData[DefaultUser].Email
+		wrong := loginBody(email, "wrong-password")
+		correct := loginBody(email, TestUserData[DefaultUser].Password)
+
+		for i := 0; i < 2; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, wrong).Code)
+		}
+		require.Equal(t, http.StatusOK, rlPost(t, h, correct).Code, "correct login should succeed and reset the counter")
+
+		// The reset gives a full bucket again: three more failures are all served
+		// (401), never throttled (429).
+		for i := 0; i < 3; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, wrong).Code, "post-reset attempt %d", i+1)
+		}
+	})
+
+	// Send endpoints: the per-account cap stays silent (same generic 200) and simply
+	// drops the extra email, so throttling can't be used to enumerate accounts.
+	t.Run("SendResetSilentPerAccount", func(t *testing.T) {
+		ac, m := rateLimitedClient(t, app, &RateLimitConfig{
+			SendEmail: Rule{
+				PerIP:      Limit{Max: 100, Window: time.Hour},
+				PerAccount: Limit{Max: 2, Window: time.Hour},
+			},
+		})
+		m.On("SendPasswordResetEmail", mock.Anything, mock.Anything).Return(nil)
+		h := ac.SendPasswordResetLinkHandler()
+		body := fmt.Sprintf(`{"email":%q}`, TestUserData[DefaultUser].Email)
+
+		for i := 0; i < 3; i++ {
+			require.Equal(t, http.StatusOK, rlPost(t, h, body).Code, "every response stays a generic 200 (attempt %d)", i+1)
+		}
+		m.AssertNumberOfCalls(t, "SendPasswordResetEmail", 2)
+	})
+
+	// Send endpoints: coarse per-IP abuse (across different accounts) does get an
+	// honest 429, since it reveals nothing about any single account.
+	t.Run("SendPerIPReturns429", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, &RateLimitConfig{
+			SendEmail: Rule{
+				PerIP:      Limit{Max: 2, Window: time.Hour},
+				PerAccount: Limit{Max: 100, Window: time.Hour},
+			},
+		})
+		h := ac.SendPasswordResetLinkHandler()
+		// Distinct unknown addresses: per-account never trips, per-IP does.
+		var last *httptest.ResponseRecorder
+		for _, e := range []string{"a@example.com", "b@example.com", "c@example.com"} {
+			last = rlPost(t, h, fmt.Sprintf(`{"email":%q}`, e))
+		}
+		require.Equal(t, http.StatusTooManyRequests, last.Code)
+		require.NotEmpty(t, last.Header().Get("Retry-After"))
+	})
+
+	// The off switch fully disables limiting.
+	t.Run("Disabled", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, &RateLimitConfig{
+			Enabled: Ptr(false),
+			Login:   Rule{PerIP: Limit{Max: 1, Window: time.Hour}},
+		})
+		h := ac.LoginHandler()
+		body := loginBody("nobody@example.com", "wrong-password")
+		for i := 0; i < 5; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, body).Code, "attempt %d should never be throttled", i+1)
+		}
+	})
+
+	// A nil RateLimit config is ON with defaults (per-account login default is 5).
+	t.Run("OnByDefault", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, nil)
+		h := ac.LoginHandler()
+		body := loginBody("default-on@example.com", "wrong-password")
+		for i := 0; i < 5; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, body).Code, "attempt %d", i+1)
+		}
+		require.Equal(t, http.StatusTooManyRequests, rlPost(t, h, body).Code, "6th attempt should hit the default per-account cap")
+	})
+
+	// The Postgres backend enforces the same behaviour via the rate_limits table,
+	// exercising the migration and the atomic token-bucket SQL.
+	t.Run("PostgresBackendReturns429", func(t *testing.T) {
+		ac, _ := rateLimitedClient(t, app, &RateLimitConfig{
+			Backend: RateLimitPostgres,
+			Login: Rule{
+				PerIP:      Limit{Max: 3, Window: time.Minute},
+				PerAccount: Limit{Max: 100, Window: time.Minute},
+			},
+		})
+		h := ac.LoginHandler()
+		body := loginBody("pg-nobody@example.com", "wrong-password")
+		for i := 0; i < 3; i++ {
+			require.Equal(t, http.StatusUnauthorized, rlPost(t, h, body).Code, "attempt %d", i+1)
+		}
+		rr := rlPost(t, h, body)
+		require.Equal(t, http.StatusTooManyRequests, rr.Code)
+		require.NotEmpty(t, rr.Header().Get("Retry-After"))
+	})
+}

--- a/core/ratelimit_memory.go
+++ b/core/ratelimit_memory.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+)
+
+// tokenBucket is one key's bucket. capacity and refill are recorded so the sweeper
+// can evict buckets that have (or would have) refilled to full without re-deriving
+// them from a Rule.
+type tokenBucket struct {
+	tokens   float64
+	capacity float64
+	refill   float64 // tokens per second
+	last     time.Time
+}
+
+// memoryRateLimiter is an in-process token-bucket RateLimiter. It is the default
+// backend: correct and dependency-free for a single instance, but its counters are
+// per-process (so N replicas allow N times the limit) and reset on restart.
+//
+// Idle buckets are swept opportunistically (no background goroutine): a bucket that
+// has refilled to full carries no state, so dropping it bounds memory without changing
+// behaviour.
+type memoryRateLimiter struct {
+	mu         sync.Mutex
+	buckets    map[string]*tokenBucket
+	now        func() time.Time // injectable for tests
+	sweepEvery time.Duration
+	nextSweep  time.Time
+}
+
+func newMemoryRateLimiter() *memoryRateLimiter {
+	return &memoryRateLimiter{
+		buckets:    make(map[string]*tokenBucket),
+		now:        time.Now,
+		sweepEvery: 10 * time.Minute,
+	}
+}
+
+func (m *memoryRateLimiter) Allow(_ context.Context, key string, limit int, window time.Duration) (bool, time.Duration, error) {
+	if limit <= 0 || window <= 0 {
+		return true, 0, nil
+	}
+	capacity := float64(limit)
+	refill := capacity / window.Seconds()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	m.sweepLocked(now)
+
+	b, ok := m.buckets[key]
+	if !ok {
+		b = &tokenBucket{tokens: capacity, capacity: capacity, refill: refill, last: now}
+		m.buckets[key] = b
+	} else {
+		if elapsed := now.Sub(b.last).Seconds(); elapsed > 0 {
+			b.tokens = math.Min(capacity, b.tokens+elapsed*refill)
+		}
+		b.capacity = capacity
+		b.refill = refill
+		b.last = now
+	}
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true, 0, nil
+	}
+	retryAfter := time.Duration((1 - b.tokens) / refill * float64(time.Second))
+	return false, retryAfter, nil
+}
+
+func (m *memoryRateLimiter) Reset(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.buckets, key)
+	return nil
+}
+
+// sweepLocked drops buckets that have refilled to full since they were last touched.
+// Runs at most once per sweepEvery. Callers must hold m.mu.
+func (m *memoryRateLimiter) sweepLocked(now time.Time) {
+	if now.Before(m.nextSweep) {
+		return
+	}
+	m.nextSweep = now.Add(m.sweepEvery)
+	for k, b := range m.buckets {
+		if b.refill <= 0 {
+			delete(m.buckets, k)
+			continue
+		}
+		if b.tokens+now.Sub(b.last).Seconds()*b.refill >= b.capacity {
+			delete(m.buckets, k)
+		}
+	}
+}

--- a/core/ratelimit_postgres.go
+++ b/core/ratelimit_postgres.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"context"
+	"time"
+)
+
+// postgresRateLimiter adapts the Postgres-backed token-bucket store to the
+// RateLimiter interface, translating the {limit, window} contract into the store's
+// {capacity, refillPerSecond} token-bucket parameters.
+type postgresRateLimiter struct {
+	store interface {
+		Allow(ctx context.Context, key string, capacity, refillPerSecond float64) (bool, time.Duration, error)
+		Reset(ctx context.Context, key string) error
+	}
+}
+
+var _ RateLimiter = (*postgresRateLimiter)(nil)
+
+func (p *postgresRateLimiter) Allow(ctx context.Context, key string, limit int, window time.Duration) (bool, time.Duration, error) {
+	if limit <= 0 || window <= 0 {
+		return true, 0, nil
+	}
+	capacity := float64(limit)
+	refillPerSecond := capacity / window.Seconds()
+	return p.store.Allow(ctx, key, capacity, refillPerSecond)
+}
+
+func (p *postgresRateLimiter) Reset(ctx context.Context, key string) error {
+	return p.store.Reset(ctx, key)
+}

--- a/core/ratelimit_unit_test.go
+++ b/core/ratelimit_unit_test.go
@@ -1,0 +1,180 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryRateLimiter_AllowsUpToLimitThenBlocks(t *testing.T) {
+	m := newMemoryRateLimiter()
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		allowed, _, err := m.Allow(ctx, "k", 3, time.Minute)
+		require.NoError(t, err)
+		require.True(t, allowed, "request %d should be allowed", i+1)
+	}
+
+	allowed, retryAfter, err := m.Allow(ctx, "k", 3, time.Minute)
+	require.NoError(t, err)
+	assert.False(t, allowed, "request over the limit should be blocked")
+	assert.Greater(t, retryAfter, time.Duration(0), "a blocked request should report a positive Retry-After")
+}
+
+func TestMemoryRateLimiter_RefillsOverTime(t *testing.T) {
+	m := newMemoryRateLimiter()
+	now := time.Now()
+	m.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	// limit 2 / 2s => refill of 1 token per second.
+	allow := func() (bool, time.Duration) {
+		a, r, err := m.Allow(ctx, "k", 2, 2*time.Second)
+		require.NoError(t, err)
+		return a, r
+	}
+
+	a, _ := allow()
+	require.True(t, a)
+	a, _ = allow()
+	require.True(t, a)
+	a, retry := allow()
+	require.False(t, a, "bucket should be empty after 2 requests")
+	assert.InDelta(t, time.Second.Seconds(), retry.Seconds(), 0.05, "should need ~1s to refill 1 token")
+
+	// After 1 second, exactly one token is available again.
+	now = now.Add(time.Second)
+	a, _ = allow()
+	assert.True(t, a, "one token should have refilled")
+	a, _ = allow()
+	assert.False(t, a, "only one token should have refilled")
+}
+
+func TestMemoryRateLimiter_Reset(t *testing.T) {
+	m := newMemoryRateLimiter()
+	ctx := context.Background()
+
+	a, _, _ := m.Allow(ctx, "k", 1, time.Minute)
+	require.True(t, a)
+	a, _, _ = m.Allow(ctx, "k", 1, time.Minute)
+	require.False(t, a)
+
+	require.NoError(t, m.Reset(ctx, "k"))
+
+	a, _, _ = m.Allow(ctx, "k", 1, time.Minute)
+	assert.True(t, a, "Reset should refill the bucket")
+}
+
+func TestMemoryRateLimiter_ZeroLimitAlwaysAllows(t *testing.T) {
+	m := newMemoryRateLimiter()
+	ctx := context.Background()
+	for i := 0; i < 100; i++ {
+		a, _, err := m.Allow(ctx, "k", 0, time.Minute)
+		require.NoError(t, err)
+		require.True(t, a)
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		proxy      *TrustedProxyConfig
+		want       string
+	}{
+		{
+			name:       "no proxy config uses direct peer",
+			remoteAddr: "203.0.113.9:5555",
+			xff:        "1.1.1.1",
+			proxy:      nil,
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "proxy header not trusted uses direct peer",
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "1.1.1.1, 2.2.2.2",
+			proxy:      &TrustedProxyConfig{TrustForwardedHeader: false},
+			want:       "10.0.0.1",
+		},
+		{
+			name:       "one trusted hop takes rightmost forwarded entry",
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "1.1.1.1, 2.2.2.2",
+			proxy:      &TrustedProxyConfig{TrustForwardedHeader: true, TrustedHops: 1},
+			want:       "2.2.2.2",
+		},
+		{
+			name:       "two trusted hops walk further left",
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "1.1.1.1, 2.2.2.2",
+			proxy:      &TrustedProxyConfig{TrustForwardedHeader: true, TrustedHops: 2},
+			want:       "1.1.1.1",
+		},
+		{
+			name:       "more hops than present falls back to direct peer",
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "1.1.1.1, 2.2.2.2",
+			proxy:      &TrustedProxyConfig{TrustForwardedHeader: true, TrustedHops: 9},
+			want:       "10.0.0.1",
+		},
+		{
+			name:       "trusted but no forwarded header uses direct peer",
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "",
+			proxy:      &TrustedProxyConfig{TrustForwardedHeader: true, TrustedHops: 1},
+			want:       "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := &AuthClient{trustedProxy: tt.proxy}
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			assert.Equal(t, tt.want, ac.clientIP(req))
+		})
+	}
+}
+
+func TestResolveRateLimitRules(t *testing.T) {
+	t.Run("nil config enables conservative defaults", func(t *testing.T) {
+		rl := resolveRateLimitRules(nil)
+		assert.True(t, rl.enabled)
+		assert.Equal(t, 10, rl.login.perIP.limit)
+		assert.Equal(t, 15*time.Minute, rl.login.perIP.window)
+		assert.Equal(t, 5, rl.login.perAccount.limit)
+		assert.Equal(t, 3, rl.sendEmail.perAccount.limit)
+		assert.Equal(t, 10, rl.register.perIP.limit)
+	})
+
+	t.Run("Enabled false disables limiting", func(t *testing.T) {
+		rl := resolveRateLimitRules(&RateLimitConfig{Enabled: Ptr(false)})
+		assert.False(t, rl.enabled)
+	})
+
+	t.Run("negative Max disables a single dimension", func(t *testing.T) {
+		rl := resolveRateLimitRules(&RateLimitConfig{
+			Login: Rule{PerIP: Limit{Max: -1}},
+		})
+		assert.False(t, rl.login.perIP.enabled(), "per-IP should be disabled")
+		assert.True(t, rl.login.perAccount.enabled(), "per-account should still use the default")
+	})
+
+	t.Run("explicit values override defaults", func(t *testing.T) {
+		rl := resolveRateLimitRules(&RateLimitConfig{
+			Login: Rule{PerIP: Limit{Max: 42, Window: 2 * time.Hour}},
+		})
+		assert.Equal(t, 42, rl.login.perIP.limit)
+		assert.Equal(t, 2*time.Hour, rl.login.perIP.window)
+	})
+}

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -104,6 +104,15 @@ func NewTestApp(env *Env, c *AuthConfig) (*TestApp, error) {
 func (a *TestApp) Router() *chi.Mux {
 	r := chi.NewRouter()
 
+	// Rate limiting is on by default in the library, but Router() builds a fresh
+	// client (and in-memory limiter) per call and most tests share the constant
+	// httptest RemoteAddr, so default it OFF here. Tests that exercise rate limiting
+	// build their own client with an explicit RateLimit config.
+	rl := a.config.RateLimit
+	if rl == nil {
+		rl = &RateLimitConfig{Enabled: Ptr(false)}
+	}
+
 	ac, err := NewAuthClient(&AuthConfig{
 		Db: &DatabaseConfig{
 			Dsn: a.env.DSN,
@@ -115,6 +124,8 @@ func (a *TestApp) Router() *chi.Mux {
 		Hooks:         a.config.Hooks,
 		BaseURL:       a.config.BaseURL,
 		SessionSecret: a.env.SessionSecret,
+		RateLimit:     rl,
+		TrustedProxy:  a.config.TrustedProxy,
 	})
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Summary

Closes four production-readiness gaps identified in a security review of the library, in one focused PR:

1. **Token-bucket rate limiting** on the auth endpoints — on by default
2. **Proxy-aware client IP** resolution (prerequisite for correct IP keying behind a load balancer)
3. **`sessions.user_id` index** (the session-management queries were sequential scans)
4. **Reference `net/smtp` mailer** so the email flows work out of the box

## Rate limiting

- **Algorithm:** token bucket, derived from a friendly `{Max, Window}` config (`capacity = Max`, `refill = Max/Window`). No boundary-burst weakness, O(1) state per key, clean `Retry-After`.
- **Backends:** a `RateLimiter` interface with an **in-memory** default (single node) and a **Postgres** backend (`Backend: RateLimitPostgres`, shared across replicas via the existing pool). Custom stores (e.g. Redis) plug in via `Store`.
- **Dimensions:** per-IP **and** per-account soft throttle. A successful login **resets** the account counter — no permanent lockout, so it can't be weaponized against a known victim.
- **Placement:** in the core handlers; login is throttled **before the bcrypt compare**, closing the CPU-exhaustion vector.
- **Anti-enumeration preserved:** on the email-sending endpoints, per-IP abuse gets an honest `429 + Retry-After`, but the per-account cap stays **silent** (the generic 200 is unchanged and the extra email is dropped), so throttling can't be used to enumerate accounts.
- **Endpoints:** login, register, reset-password, resend-verification, magic-link, change-password, change-email.
- **`EventRateLimited` hook** fires on every throttle (flow / dimension / key / retry-after) for logging, metrics or alerting.
- **Fail-open:** a limiter error logs loudly and allows the request — a counter-store hiccup never becomes an auth outage.

### DX

```go
// Zero config: on by default with conservative limits.
core.NewAuthClient(&core.AuthConfig{ Db: ... })

// Tune limits:
RateLimit: &core.RateLimitConfig{
    Login: core.Rule{
        PerIP:      core.Limit{Max: 10, Window: 15 * time.Minute},
        PerAccount: core.Limit{Max: 5,  Window: 15 * time.Minute},
    },
},

// Scale horizontally + sit behind a load balancer:
RateLimit:    &core.RateLimitConfig{Backend: core.RateLimitPostgres},
TrustedProxy: &core.TrustedProxyConfig{TrustForwardedHeader: true, TrustedHops: 1},

// Turn it off:
RateLimit: &core.RateLimitConfig{Enabled: core.Ptr(false)},
```

## Proxy-aware client IP

`TrustedProxyConfig` opts into `X-Forwarded-For` parsing with a declared `TrustedHops` count (the client IP is taken that many entries from the right, so a spoofed left-most value is ignored). Defaults to `RemoteAddr`, and falls back to the direct peer on any ambiguity.

## Reference SMTP mailer

`mailer.NewSMTP(mailer.SMTPConfig{...})` — authenticated submission over STARTTLS/587, plain-text templates with links built from `BaseURL`. The `fmt.Printf` stub remains the dev default.

## Migration

`000002_rate_limits_and_session_index` adds the `sessions_user_id` index and the `rate_limits` table (used only by the Postgres backend).

## Testing

- Unit tests: token-bucket allow/refill/reset, client-IP derivation (table), config resolution — no DB.
- Integration tests (7 subtests): login per-IP 429, reset-on-success, silent per-account drop, send per-IP 429, off-switch, on-by-default, Postgres backend.
- `gofmt` clean · `go vet ./...` clean · `golangci-lint run ./...` → **0 issues** · full suite green (`core`, `adapters/conformance`, `internal/auth`).

No breaking changes — all additions are additive and the `Mailer` interface is unchanged.

## Follow-ups (deliberately out of scope)

- First-party **Redis** rate-limit adapter (`adapters/ratelimit/redis`, Lua-backed) — consumers can implement the `RateLimiter` interface today.
- **CSRF** double-submit token for `SameSite=None` deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
